### PR TITLE
Template generalization: remove all hardcoded disc assumptions

### DIFF
--- a/Docs/plans/2026-03-15-template-generalization-design.md
+++ b/Docs/plans/2026-03-15-template-generalization-design.md
@@ -1,0 +1,281 @@
+# Template Generalization Design
+
+**Date**: 2026-03-15
+**Status**: Approved
+**Issue**: Extends #34 (infrastructure refactoring)
+
+## Problem
+
+FoamScript's pipeline (mesh, solve, report) is hardcoded around disc-golf CFD assumptions. An audit found 20 disc-specific assumptions: 9 blocking (will crash for non-disc templates), 7 misleading (wrong output), 4 cosmetic. This prevents adding airfoil, duct, heat transfer, and other templates without per-template workarounds.
+
+## Design Principles
+
+1. **TEMPLATE.json is the single source of truth** — every template-specific behavior is declared there. No hardcoded defaults in C#.
+2. **Every JSON field is CLI-overridable** — the user can override any template default from the command line.
+3. **No silent fallbacks** — if TEMPLATE.json is missing, foamscript refuses to run with a clear error.
+4. **Breaking changes are acceptable** — small community, early development cycle. Document and move forward.
+5. **Template authors encode expertise** — the template gets the pipeline right once; end users just provide geometry + parameters.
+
+## TEMPLATE.json Schema
+
+Every template ships a complete TEMPLATE.json. No field is optional for the template author.
+
+```json
+{
+  "name": "external_disc_rotatingwall_steady",
+  "description": "Steady-state rotating disc analysis (simpleFoam + rotatingWallVelocity)",
+  "solver": "simpleFoam",
+
+  "geometry": {
+    "type": "disc",
+    "stlName": "disc.stl",
+    "requiredStlFiles": ["disc.stl", "tunnel.stl"],
+    "surfaceOrient": { "outsidePoint": [0, 0, -1] }
+  },
+
+  "reference": {
+    "dimension": "diameter",
+    "areaFormula": "circular"
+  },
+
+  "rotation": {
+    "enabled": true,
+    "requiresRotorZone": true
+  },
+
+  "validation": {
+    "minSize": 0.18,
+    "maxSize": 0.35,
+    "warningMessage": "Geometry size outside expected range for disc template."
+  },
+
+  "parameters": {
+    "velocity": { "required": true, "description": "Freestream velocity (m/s)" },
+    "rpm": { "required": true, "description": "Rotational speed (RPM)" },
+    "angles": { "required": true, "description": "Angle(s) of attack (degrees)" },
+    "refinementMin": { "required": false, "default": 5, "description": "Minimum refinement level" },
+    "refinementMax": { "required": false, "default": 6, "description": "Maximum refinement level" },
+    "maxIterations": { "required": false, "default": 500, "description": "Maximum solver iterations" },
+    "turbulenceIntensity": { "required": false, "default": 0.01, "description": "Turbulence intensity (0-1)" }
+  },
+
+  "domain": {
+    "upstream": 5.0,
+    "downstream": 10.0,
+    "radial": 5.0
+  },
+
+  "meshPipeline": [
+    { "command": "blockMesh", "args": "-case {caseDir}" },
+    { "command": "surfaceOrient", "args": "{geometry.stlPath} \"(0 0 -1)\" {geometry.stlPath}", "optional": true },
+    { "command": "surfaceFeatureExtract", "args": "-case {caseDir}" },
+    { "command": "decomposePar", "args": "-case {caseDir}", "parallel": false },
+    { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true },
+    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant", "parallel": false },
+    { "command": "checkMesh", "args": "-case {caseDir}", "parallel": false }
+  ],
+
+  "solvePipeline": [
+    { "command": "decomposePar", "args": "-case {caseDir} -force", "parallel": false },
+    { "command": "simpleFoam", "args": "-case {caseDir}", "parallel": true },
+    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime", "parallel": false }
+  ],
+
+  "results": {
+    "type": "forceCoefficients",
+    "dataFile": "postProcessing/forces/0/coefficient.dat",
+    "columns": {
+      "Cd": 1,
+      "Cl": 4,
+      "CmPitch": 7
+    }
+  },
+
+  "report": {
+    "template": "report/report.html",
+    "standard": "AIAA",
+    "postProcess": [
+      { "function": "surfaces", "args": "-case {caseDir} -latestTime" }
+    ]
+  }
+}
+```
+
+### Airfoil Example (differences)
+
+```json
+{
+  "geometry": {
+    "type": "airfoil",
+    "stlName": "airfoil.stl",
+    "requiredStlFiles": ["airfoil.stl"],
+    "surfaceOrient": null
+  },
+  "rotation": { "enabled": false, "requiresRotorZone": false },
+  "validation": null,
+  "parameters": {
+    "velocity": { "required": true },
+    "rpm": null,
+    "angles": { "required": true }
+  }
+}
+```
+
+## CLI Parameter Flow
+
+1. User runs: `foamscript new-study --template <name> --velocity 26 --angles 0,5,10 ...`
+2. foamscript loads TEMPLATE.json from the template directory
+3. Validates all `"required": true` parameters were provided via CLI
+4. If missing: error with clear message — `"Template 'external_disc_rotatingwall_steady' requires --rpm but it was not provided"`
+5. Optional parameters not provided use the template's declared default
+
+### Changes from current behavior
+
+- `--template` becomes **required** (no default)
+- `--velocity`, `--rpm`, etc. become nullable in C# model (no hardcoded defaults)
+- Template `parameters` section declares required vs optional per template
+- Universal physics constants (nu=1.5e-5, TI=0.01) remain available with sensible defaults because they're fluid properties, not geometry properties
+
+## Mesh Pipeline
+
+MeshService becomes a generic pipeline executor. It reads the `meshPipeline` array from TEMPLATE.json and runs each step in order.
+
+- `{caseDir}` and `{geometry.stlPath}` tokens resolved at runtime
+- `"parallel": true` → run via mpirun with the configured core count
+- `"optional": true` → non-zero exit is a warning, not a failure
+- No hardcoded steps in C# — the template controls the entire pipeline
+
+This supports future templates that need different pipelines (e.g., blockMesh-only for structured internal flow, setFields for multiphase, createBaffles for heat transfer).
+
+## Solve Pipeline
+
+Same pattern as mesh. SolverService reads the `solvePipeline` array and executes.
+
+Current hardcoded pipeline (decomposePar → simpleFoam → reconstructPar) becomes the disc/airfoil template's declared pipeline. Future templates can add pre-steps (potentialFoam initialization, setFields) or use different solvers (pimpleFoam, interFoam).
+
+## Results Extraction
+
+Currently hardcoded to parse `postProcessing/forces/0/coefficient.dat` with fixed column indices. The new approach:
+
+- Template declares `results.dataFile` path and `results.columns` mapping
+- C# results parser becomes generic: read file, extract declared columns, report by name
+- Works for any OpenFOAM postProcessing output (force coefficients, field averages, surface values)
+
+Future non-aero templates can declare different result types:
+```json
+{
+  "results": {
+    "type": "fieldAverage",
+    "dataFile": "postProcessing/fieldAverage/0/surfaceFieldValue.dat",
+    "columns": { "pressureDrop": 1, "massFlowRate": 2 }
+  }
+}
+```
+
+## Report Generation
+
+### Architecture
+
+Each template ships its own Scriban report template in `report/report.html` alongside its OpenFOAM files. The C# ReportService becomes a generic rendering engine.
+
+### Template directory structure
+
+```
+Templates/
+  external_disc_rotatingwall_steady/
+    0/ constant/ system/
+    TEMPLATE.json
+    report/
+      report.html          ← disc-specific AIAA report
+  external_airfoil_static_steady/
+    0/ constant/ system/
+    TEMPLATE.json
+    report/
+      report.html          ← airfoil-specific report
+```
+
+### What moves out of C#
+
+Chart labels, column names, section headings, report layout — all into the Scriban template. The C# code provides data and renders.
+
+### What stays in C#
+
+- PDF generation (PDFsharp) — generic renderer
+- CSV export — writes whatever columns `results` declared
+- Convergence/residual parsing — universal OpenFOAM log format
+- ScottPlot chart generation — generic, data-driven
+
+### Visualization (Python elimination)
+
+Current Python scripts (`extract_slice.py`, `render_slice.py`) are replaced by:
+1. OpenFOAM's built-in `postProcess` function objects to export slice/surface data
+2. ScottPlot (already a project dependency) to render charts in C#
+
+This eliminates the undeclared Python/ParaView dependency. Templates declare postProcess steps in `report.postProcess`.
+
+### Disc report migration
+
+The existing disc-golf report (AIAA formatting, Cd/Cl/Cm tables, polar curves, convergence plots, flow visualization) is migrated into the disc template directory. No functionality is lost — it just lives inside the template instead of being hardcoded in C#.
+
+## Domain Sizing
+
+Help text changes from "in disc diameters" to "in reference lengths". The `domain` section in TEMPLATE.json declares upstream/downstream/radial multipliers. These are applied to the template's reference dimension (diameter for disc, chord for airfoil).
+
+## Hardcoded Assumptions — Full Resolution
+
+### Blocking (9 issues)
+
+| Issue | Resolution |
+|-------|-----------|
+| Default template hardcoding | `--template` required, no default |
+| Rotor zone assumption | `rotation.requiresRotorZone` in TEMPLATE.json |
+| disc.stl surfaceOrient | `meshPipeline` declares orient step (or omits it) |
+| Required STL files default | `geometry.requiredStlFiles` in TEMPLATE.json |
+| Geometry STL filename default | `geometry.stlName` in TEMPLATE.json |
+| Force coefficient extraction path | `results.dataFile` in TEMPLATE.json |
+| Coefficient column indices | `results.columns` mapping in TEMPLATE.json |
+| Reference dimension default | `reference.dimension` in TEMPLATE.json |
+| Reference area formula default | `reference.areaFormula` in TEMPLATE.json |
+
+### Misleading (7 issues)
+
+| Issue | Resolution |
+|-------|-----------|
+| velocity=27/rpm=925 defaults | Nullable CLI flags; template `parameters` declares required/optional |
+| Domain sizing "disc diameters" | Renamed to "reference lengths" in help text |
+| Report CSV header (Cd/Cl/Cm) | Generated from `results.columns` dynamically |
+| RPM in reports | Only included if `rotation.enabled` |
+| Chart labels (aero-specific) | Moved to template's report Scriban file |
+| PDGA validation range | Moved to template's `validation` section |
+| Rotor deltaT comment | Removed; rotor logic guarded by `rotation.enabled` |
+
+### Cosmetic (4 issues)
+
+| Issue | Resolution |
+|-------|-----------|
+| `disc_diameter` template alias | Replaced with `ref_length` (already exists) |
+| `discStlFile` parameter name | Renamed to `geometryStlFile` |
+| rotor/rotor_slave patch names | Guarded by `rotation.enabled`; non-rotating templates skip |
+| Turbulence intensity AIAA bias | Moved to template `parameters` defaults |
+
+## Breaking Changes
+
+These changes break backward compatibility for existing users:
+
+1. `--template` flag is now required for `new-study`
+2. `--velocity` and `--rpm` no longer have defaults — must be provided explicitly (or declared in template)
+3. Existing disc templates require updated TEMPLATE.json with full schema
+4. Report output may differ slightly as rendering moves to template-driven Scriban
+
+Document these in release notes and CHANGELOG.
+
+## Testing Strategy
+
+1. Schema validation tests — TEMPLATE.json parsing, required field enforcement
+2. Pipeline executor tests — mock command execution, token resolution
+3. Parameter validation tests — required/optional enforcement, CLI override
+4. Results parser tests — generic column extraction from various file formats
+5. Report rendering tests — Scriban template rendering with dynamic data
+6. E2E: disc template produces identical results to current behavior
+7. E2E: airfoil template (already validated) works with new schema
+8. Migration: existing disc studies produce equivalent reports

--- a/Docs/plans/2026-03-15-template-generalization-impl.md
+++ b/Docs/plans/2026-03-15-template-generalization-impl.md
@@ -1,0 +1,965 @@
+# Template Generalization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove all 20 hardcoded disc assumptions from foamscript so every template-specific behavior is driven by TEMPLATE.json.
+
+**Architecture:** Expand TEMPLATE.json schema to include mesh/solve pipelines, parameter declarations, results extraction config, and report config. Refactor C# services from hardcoded logic to generic pipeline executors. Migrate existing disc report into template directory.
+
+**Tech Stack:** .NET 10, System.Text.Json, Scriban, ScottPlot, xUnit + FluentAssertions
+
+**Design doc:** `Docs/plans/2026-03-15-template-generalization-design.md`
+
+---
+
+## Task 1: Expand TemplateMetadata Model
+
+**Files:**
+- Modify: `Models/TemplateMetadata.cs`
+- Test: `foamscript.Tests/Services/TemplateMetadataServiceTests.cs`
+
+**Step 1: Write failing tests for new schema fields**
+
+Add tests that deserialize TEMPLATE.json with the expanded schema (geometry, parameters, meshPipeline, solvePipeline, results, report sections). These will fail because the model doesn't have the new properties yet.
+
+```csharp
+[Fact]
+public void LoadMetadata_ExpandedSchema_ParsesAllSections()
+{
+    var dir = CreateTempDir();
+    File.WriteAllText(Path.Combine(dir, "TEMPLATE.json"), """
+    {
+      "name": "test_template",
+      "description": "Test",
+      "solver": "simpleFoam",
+      "geometry": {
+        "type": "disc",
+        "stlName": "disc.stl",
+        "requiredStlFiles": ["disc.stl", "tunnel.stl"],
+        "surfaceOrient": { "outsidePoint": [0, 0, -1] }
+      },
+      "reference": {
+        "dimension": "diameter",
+        "areaFormula": "circular"
+      },
+      "rotation": {
+        "enabled": true,
+        "requiresRotorZone": true
+      },
+      "parameters": {
+        "velocity": { "required": true, "description": "Freestream velocity (m/s)" },
+        "rpm": { "required": true, "description": "Rotational speed" }
+      },
+      "domain": {
+        "upstream": 5.0,
+        "downstream": 10.0,
+        "radial": 5.0
+      },
+      "meshPipeline": [
+        { "command": "blockMesh", "args": "-case {caseDir}" },
+        { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true }
+      ],
+      "solvePipeline": [
+        { "command": "decomposePar", "args": "-case {caseDir} -force" },
+        { "command": "simpleFoam", "args": "-case {caseDir}", "parallel": true },
+        { "command": "reconstructPar", "args": "-case {caseDir} -latestTime" }
+      ],
+      "results": {
+        "type": "forceCoefficients",
+        "dataFile": "postProcessing/forces/0/coefficient.dat",
+        "columns": { "Cd": 1, "Cl": 4, "CmPitch": 7 }
+      },
+      "report": {
+        "template": "report/report.html",
+        "standard": "AIAA"
+      }
+    }
+    """);
+
+    var metadata = _service.LoadMetadata(dir);
+
+    metadata.Name.Should().Be("test_template");
+    metadata.Geometry.Type.Should().Be("disc");
+    metadata.Geometry.StlName.Should().Be("disc.stl");
+    metadata.Geometry.SurfaceOrient.Should().NotBeNull();
+    metadata.Geometry.SurfaceOrient!.OutsidePoint.Should().BeEquivalentTo(new[] { 0.0, 0, -1 });
+    metadata.Reference.Dimension.Should().Be("diameter");
+    metadata.Rotation.Enabled.Should().BeTrue();
+    metadata.Parameters.Should().ContainKey("velocity");
+    metadata.Parameters["velocity"].Required.Should().BeTrue();
+    metadata.MeshPipeline.Should().HaveCount(2);
+    metadata.MeshPipeline[1].Parallel.Should().BeTrue();
+    metadata.SolvePipeline.Should().HaveCount(3);
+    metadata.Results.DataFile.Should().Be("postProcessing/forces/0/coefficient.dat");
+    metadata.Results.Columns.Should().ContainKey("Cd");
+    metadata.Report.Template.Should().Be("report/report.html");
+}
+
+[Fact]
+public void LoadMetadata_MissingFile_ThrowsFileNotFoundException()
+{
+    var dir = CreateTempDir();
+    var act = () => _service.LoadMetadata(dir);
+    act.Should().Throw<FileNotFoundException>()
+        .WithMessage("*TEMPLATE.json*");
+}
+
+[Fact]
+public void LoadMetadata_NullSurfaceOrient_ParsesAsNull()
+{
+    var dir = CreateTempDir();
+    File.WriteAllText(Path.Combine(dir, "TEMPLATE.json"), """
+    {
+      "name": "airfoil_test",
+      "solver": "simpleFoam",
+      "geometry": {
+        "type": "airfoil",
+        "stlName": "airfoil.stl",
+        "requiredStlFiles": ["airfoil.stl"],
+        "surfaceOrient": null
+      },
+      "reference": { "dimension": "chord", "areaFormula": "rectangular" },
+      "rotation": { "enabled": false, "requiresRotorZone": false },
+      "parameters": {
+        "velocity": { "required": true }
+      },
+      "domain": { "upstream": 5.0, "downstream": 10.0, "radial": 5.0 },
+      "meshPipeline": [],
+      "solvePipeline": [],
+      "results": { "type": "forceCoefficients", "dataFile": "postProcessing/forces/0/coefficient.dat", "columns": { "Cd": 1, "Cl": 4 } },
+      "report": { "template": "report/report.html" }
+    }
+    """);
+
+    var metadata = _service.LoadMetadata(dir);
+    metadata.Geometry.SurfaceOrient.Should().BeNull();
+    metadata.Rotation.Enabled.Should().BeFalse();
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `dotnet test --filter "TemplateMetadataServiceTests"`
+Expected: compilation errors — new properties don't exist yet.
+
+**Step 3: Expand TemplateMetadata model**
+
+Replace the flat properties in `Models/TemplateMetadata.cs` with nested objects:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace foamscript.Models
+{
+    public class TemplateMetadata
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonPropertyName("solver")]
+        public string Solver { get; set; } = string.Empty;
+
+        [JsonPropertyName("geometry")]
+        public GeometryConfig Geometry { get; set; } = new();
+
+        [JsonPropertyName("reference")]
+        public ReferenceConfig Reference { get; set; } = new();
+
+        [JsonPropertyName("rotation")]
+        public RotationConfig Rotation { get; set; } = new();
+
+        [JsonPropertyName("validation")]
+        public GeometryValidation? Validation { get; set; }
+
+        [JsonPropertyName("parameters")]
+        public Dictionary<string, ParameterDef> Parameters { get; set; } = new();
+
+        [JsonPropertyName("domain")]
+        public DomainConfig Domain { get; set; } = new();
+
+        [JsonPropertyName("meshPipeline")]
+        public List<PipelineStep> MeshPipeline { get; set; } = new();
+
+        [JsonPropertyName("solvePipeline")]
+        public List<PipelineStep> SolvePipeline { get; set; } = new();
+
+        [JsonPropertyName("results")]
+        public ResultsConfig Results { get; set; } = new();
+
+        [JsonPropertyName("report")]
+        public ReportConfig Report { get; set; } = new();
+
+        // Backward-compat accessors used by existing code during migration
+        [JsonIgnore] public string GeometryType => Geometry.Type;
+        [JsonIgnore] public string GeometryStlName => Geometry.StlName;
+        [JsonIgnore] public string ReferenceDimension => Reference.Dimension;
+        [JsonIgnore] public string ReferenceAreaFormula => Reference.AreaFormula;
+        [JsonIgnore] public bool RequiresRotorZone => Rotation.RequiresRotorZone;
+        [JsonIgnore] public string[] RequiredStlFiles => Geometry.RequiredStlFiles;
+    }
+
+    public class GeometryConfig
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("stlName")]
+        public string StlName { get; set; } = string.Empty;
+
+        [JsonPropertyName("requiredStlFiles")]
+        public string[] RequiredStlFiles { get; set; } = [];
+
+        [JsonPropertyName("surfaceOrient")]
+        public SurfaceOrientConfig? SurfaceOrient { get; set; }
+    }
+
+    public class SurfaceOrientConfig
+    {
+        [JsonPropertyName("outsidePoint")]
+        public double[] OutsidePoint { get; set; } = [];
+    }
+
+    public class ReferenceConfig
+    {
+        [JsonPropertyName("dimension")]
+        public string Dimension { get; set; } = string.Empty;
+
+        [JsonPropertyName("areaFormula")]
+        public string AreaFormula { get; set; } = string.Empty;
+    }
+
+    public class RotationConfig
+    {
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        [JsonPropertyName("requiresRotorZone")]
+        public bool RequiresRotorZone { get; set; }
+    }
+
+    public class ParameterDef
+    {
+        [JsonPropertyName("required")]
+        public bool Required { get; set; }
+
+        [JsonPropertyName("default")]
+        public double? Default { get; set; }
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+    }
+
+    public class DomainConfig
+    {
+        [JsonPropertyName("upstream")]
+        public double Upstream { get; set; } = 5.0;
+
+        [JsonPropertyName("downstream")]
+        public double Downstream { get; set; } = 10.0;
+
+        [JsonPropertyName("radial")]
+        public double Radial { get; set; } = 5.0;
+    }
+
+    public class PipelineStep
+    {
+        [JsonPropertyName("command")]
+        public string Command { get; set; } = string.Empty;
+
+        [JsonPropertyName("args")]
+        public string Args { get; set; } = string.Empty;
+
+        [JsonPropertyName("parallel")]
+        public bool Parallel { get; set; }
+
+        [JsonPropertyName("optional")]
+        public bool Optional { get; set; }
+    }
+
+    public class ResultsConfig
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("dataFile")]
+        public string DataFile { get; set; } = string.Empty;
+
+        [JsonPropertyName("columns")]
+        public Dictionary<string, int> Columns { get; set; } = new();
+    }
+
+    public class ReportConfig
+    {
+        [JsonPropertyName("template")]
+        public string Template { get; set; } = string.Empty;
+
+        [JsonPropertyName("standard")]
+        public string? Standard { get; set; }
+
+        [JsonPropertyName("postProcess")]
+        public List<PostProcessStep>? PostProcess { get; set; }
+    }
+
+    public class PostProcessStep
+    {
+        [JsonPropertyName("function")]
+        public string Function { get; set; } = string.Empty;
+
+        [JsonPropertyName("args")]
+        public string Args { get; set; } = string.Empty;
+    }
+
+    public class GeometryValidation
+    {
+        [JsonPropertyName("minSize")]
+        public double? MinSize { get; set; }
+
+        [JsonPropertyName("maxSize")]
+        public double? MaxSize { get; set; }
+
+        [JsonPropertyName("warningMessage")]
+        public string? WarningMessage { get; set; }
+    }
+}
+```
+
+**Step 4: Update TemplateMetadataService — remove disc fallback, fail on missing**
+
+Modify `Services/TemplateMetadataService.cs`:
+- Remove `CreateDiscDefaults()` method entirely
+- `LoadMetadata()` throws `FileNotFoundException` if TEMPLATE.json missing
+- `LoadMetadata()` throws `JsonException` if TEMPLATE.json invalid (don't catch it)
+- Update `CalculateReferenceDimension` and `CalculateReferenceArea` to use new property paths
+
+```csharp
+public TemplateMetadata LoadMetadata(string templatePath)
+{
+    var jsonPath = Path.Combine(templatePath, MetadataFileName);
+
+    if (!File.Exists(jsonPath))
+    {
+        throw new FileNotFoundException(
+            $"TEMPLATE.json not found in '{templatePath}'. Every template must include a TEMPLATE.json file.",
+            jsonPath);
+    }
+
+    var json = File.ReadAllText(jsonPath);
+    var metadata = JsonSerializer.Deserialize<TemplateMetadata>(json)
+        ?? throw new JsonException($"Failed to deserialize TEMPLATE.json in '{templatePath}'.");
+    return metadata;
+}
+```
+
+**Step 5: Update existing tests**
+
+Remove/update tests that expected disc fallback behavior:
+- `LoadMetadata_MissingFile_ReturnsDiscDefaults` → `LoadMetadata_MissingFile_ThrowsFileNotFoundException`
+- `LoadMetadata_InvalidJson_ReturnsDiscDefaults` → `LoadMetadata_InvalidJson_ThrowsJsonException`
+- Update `LoadMetadata_ValidJson_ReturnsDeserializedMetadata` to use new schema structure
+- Update `LoadMetadata_WithValidation_ParsesValidationBlock` to use new schema
+- Update `LoadMetadata_DiscTemplate_MatchesExpectedValues` — disc TEMPLATE.json must be updated first (Task 2)
+
+**Step 6: Run tests to verify they pass**
+
+Run: `dotnet test --filter "TemplateMetadataServiceTests"`
+Expected: all pass
+
+**Step 7: Commit**
+
+```bash
+git add Models/TemplateMetadata.cs Services/TemplateMetadataService.cs foamscript.Tests/Services/TemplateMetadataServiceTests.cs
+git commit -m "feat: expand TemplateMetadata schema with pipelines, parameters, results, report config
+
+BREAKING: TEMPLATE.json is now required — missing file throws FileNotFoundException.
+Removes hardcoded disc fallback defaults."
+```
+
+---
+
+## Task 2: Update All TEMPLATE.json Files to New Schema
+
+**Files:**
+- Modify: `Templates/external_disc_rotatingwall_steady/TEMPLATE.json`
+- Modify: `Templates/external_disc_rotating-ami_transient/TEMPLATE.json`
+- Modify: `Templates/external_airfoil_static_steady/TEMPLATE.json`
+
+**Step 1: Update disc steady TEMPLATE.json**
+
+```json
+{
+  "name": "external_disc_rotatingwall_steady",
+  "description": "Steady-state rotating disc analysis (simpleFoam + rotatingWallVelocity)",
+  "solver": "simpleFoam",
+  "geometry": {
+    "type": "disc",
+    "stlName": "disc.stl",
+    "requiredStlFiles": ["disc.stl", "tunnel.stl"],
+    "surfaceOrient": { "outsidePoint": [0, 0, -1] }
+  },
+  "reference": {
+    "dimension": "diameter",
+    "areaFormula": "circular"
+  },
+  "rotation": {
+    "enabled": true,
+    "requiresRotorZone": true
+  },
+  "validation": {
+    "minSize": 0.18,
+    "maxSize": 0.35,
+    "warningMessage": "Disc diameter outside expected PDGA range (0.21-0.30m). Ensure correct --input-units."
+  },
+  "parameters": {
+    "velocity": { "required": true, "description": "Freestream velocity (m/s)" },
+    "rpm": { "required": true, "description": "Rotational speed (RPM)" },
+    "angles": { "required": true, "description": "Angle(s) of attack (degrees)" },
+    "refinementMin": { "required": false, "default": 5, "description": "Minimum refinement level" },
+    "refinementMax": { "required": false, "default": 6, "description": "Maximum refinement level" },
+    "maxIterations": { "required": false, "default": 500, "description": "Maximum solver iterations" }
+  },
+  "domain": {
+    "upstream": 5.0,
+    "downstream": 10.0,
+    "radial": 5.0
+  },
+  "meshPipeline": [
+    { "command": "blockMesh", "args": "-case {caseDir}" },
+    { "command": "surfaceOrient", "args": "{geometryStlPath} \"({outsidePoint})\" {geometryStlPath}", "optional": true },
+    { "command": "surfaceFeatureExtract", "args": "-case {caseDir}" },
+    { "command": "decomposePar", "args": "-case {caseDir}" },
+    { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true },
+    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant" },
+    { "command": "checkMesh", "args": "-case {caseDir}" }
+  ],
+  "solvePipeline": [
+    { "command": "decomposePar", "args": "-case {caseDir} -force" },
+    { "command": "simpleFoam", "args": "-case {caseDir}", "parallel": true },
+    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime" }
+  ],
+  "results": {
+    "type": "forceCoefficients",
+    "dataFile": "postProcessing/forces/0/coefficient.dat",
+    "columns": { "Cd": 1, "Cl": 4, "CmPitch": 7 }
+  },
+  "report": {
+    "template": "report/report.html",
+    "standard": "AIAA"
+  }
+}
+```
+
+**Step 2: Update disc transient (AMI) TEMPLATE.json**
+
+Same structure but with `"solver": "pimpleFoam"`, `"requiredStlFiles": ["disc.stl", "rotor.stl", "tunnel.stl"]`, and pimpleFoam in solvePipeline.
+
+**Step 3: Update airfoil steady TEMPLATE.json**
+
+```json
+{
+  "name": "external_airfoil_static_steady",
+  "description": "Steady-state 2D airfoil analysis (simpleFoam + Spalart-Allmaras)",
+  "solver": "simpleFoam",
+  "geometry": {
+    "type": "airfoil",
+    "stlName": "airfoil.stl",
+    "requiredStlFiles": ["airfoil.stl"],
+    "surfaceOrient": null
+  },
+  "reference": {
+    "dimension": "chord",
+    "areaFormula": "rectangular"
+  },
+  "rotation": {
+    "enabled": false,
+    "requiresRotorZone": false
+  },
+  "validation": null,
+  "parameters": {
+    "velocity": { "required": true, "description": "Freestream velocity (m/s)" },
+    "angles": { "required": true, "description": "Angle(s) of attack (degrees)" },
+    "refinementMin": { "required": false, "default": 5, "description": "Minimum refinement level" },
+    "refinementMax": { "required": false, "default": 6, "description": "Maximum refinement level" }
+  },
+  "domain": {
+    "upstream": 5.0,
+    "downstream": 10.0,
+    "radial": 5.0
+  },
+  "meshPipeline": [
+    { "command": "blockMesh", "args": "-case {caseDir}" },
+    { "command": "surfaceFeatureExtract", "args": "-case {caseDir}" },
+    { "command": "decomposePar", "args": "-case {caseDir}" },
+    { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true },
+    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant" },
+    { "command": "checkMesh", "args": "-case {caseDir}" }
+  ],
+  "solvePipeline": [
+    { "command": "decomposePar", "args": "-case {caseDir} -force" },
+    { "command": "simpleFoam", "args": "-case {caseDir}", "parallel": true },
+    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime" }
+  ],
+  "results": {
+    "type": "forceCoefficients",
+    "dataFile": "postProcessing/forces/0/coefficient.dat",
+    "columns": { "Cd": 1, "Cl": 4, "CmPitch": 7 }
+  },
+  "report": {
+    "template": "report/report.html",
+    "standard": "AIAA"
+  }
+}
+```
+
+**Step 4: Run all tests**
+
+Run: `dotnet test`
+Expected: all pass (TemplateMetadataServiceTests updated in Task 1, plus existing test that loads disc template)
+
+**Step 5: Commit**
+
+```bash
+git add Templates/*/TEMPLATE.json
+git commit -m "feat: update all TEMPLATE.json files to expanded schema
+
+Adds meshPipeline, solvePipeline, results, report, parameters, and
+nested geometry/reference/rotation sections to all three templates."
+```
+
+---
+
+## Task 3: CLI Parameter Generalization
+
+**Files:**
+- Modify: `Models/NewStudyModel.cs`
+- Modify: `Handlers/NewStudyHandler.cs`
+- Test: `foamscript.Tests/Handlers/NewStudyHandlerTests.cs` (existing or new)
+
+**Step 1: Write failing test for required --template**
+
+```csharp
+[Fact]
+public void Handle_MissingTemplate_ReturnsError()
+{
+    // NewStudyModel with no --template should fail
+    var model = new NewStudyModel { ProjectName = "test", OutputDir = "/tmp", ModelSource = "test.stl", Angles = "0" };
+    // TemplatePath is null — handler should reject
+}
+```
+
+**Step 2: Write failing test for template-driven required params**
+
+```csharp
+[Fact]
+public void Handle_MissingRequiredParam_ReturnsError()
+{
+    // Template requires --velocity but it's not provided
+    // Should produce error: "Template 'X' requires --velocity but it was not provided"
+}
+```
+
+**Step 3: Make --template required (no default)**
+
+In `Models/NewStudyModel.cs`:
+- Change `--template` help text: remove "defaults to external_disc_rotatingwall_steady"
+- In `Handlers/NewStudyHandler.cs` `ResolveTemplatePath()`: remove the null/empty fallback to disc template. Instead, throw an error.
+
+```csharp
+private string ResolveTemplatePath(string? templatePathOrName)
+{
+    if (string.IsNullOrEmpty(templatePathOrName))
+    {
+        throw new ArgumentException("--template is required. Use 'foamscript list-templates' to see available templates.");
+    }
+    // ... rest unchanged
+}
+```
+
+**Step 4: Make velocity/rpm nullable, remove hardcoded defaults**
+
+In `Models/NewStudyModel.cs`:
+- `Velocity` → `double?` with `Default = null` (remove `Default = 27.0`)
+- `Rpm` → `double?` with `Default = null` (remove `Default = 925.0`)
+- Update help text: remove "elite amateur" references, use neutral descriptions
+
+In `Handlers/NewStudyHandler.cs`:
+- After loading TemplateMetadata, validate required parameters from `metadata.Parameters`
+- For each parameter with `"required": true`, check if the CLI provided a value
+- If CLI value is null and parameter has a `"default"` in TEMPLATE.json, use the default
+- If CLI value is null and no default, error with clear message
+
+**Step 5: Update domain help text**
+
+In `Models/NewStudyModel.cs`:
+- `--tunnel-upstream`: "in disc diameters" → "in reference lengths"
+- `--tunnel-downstream`: same
+- `--tunnel-radial`: same
+- `--rotor-radius-scale`: "multiple of disc radius" → "multiple of geometry radius"
+
+**Step 6: Run tests**
+
+Run: `dotnet test`
+Expected: all pass
+
+**Step 7: Commit**
+
+```bash
+git add Models/NewStudyModel.cs Handlers/NewStudyHandler.cs foamscript.Tests/
+git commit -m "feat: template-driven CLI parameters
+
+BREAKING: --template is now required (no default).
+BREAKING: --velocity and --rpm no longer have defaults.
+Templates declare required/optional params in TEMPLATE.json."
+```
+
+---
+
+## Task 4: Generic Mesh Pipeline Executor
+
+**Files:**
+- Modify: `Services/MeshService.cs`
+- Test: `foamscript.Tests/Services/MeshServiceTests.cs`
+
+**Step 1: Write failing test for pipeline execution**
+
+```csharp
+[Fact]
+public void MeshCase_ExecutesPipelineFromMetadata()
+{
+    // Setup: mock process executor, template metadata with meshPipeline
+    // Verify: each pipeline step is executed in order with resolved tokens
+}
+
+[Fact]
+public void MeshCase_SkipsSurfaceOrientWhenNotInPipeline()
+{
+    // Setup: airfoil metadata with no surfaceOrient in pipeline
+    // Verify: surfaceOrient is never called
+}
+
+[Fact]
+public void MeshCase_OptionalStepFailureIsWarning()
+{
+    // Setup: pipeline step with optional=true that returns non-zero
+    // Verify: result.Success is true, result.Warnings contains message
+}
+```
+
+**Step 2: Implement generic pipeline executor in MeshService**
+
+Replace the hardcoded blockMesh → surfaceOrient → surfaceFeatureExtract → ... sequence with:
+
+```csharp
+// Load metadata from TEMPLATE.json in case directory
+var metadata = _metadataService.LoadMetadata(Path.Combine(caseDir));
+
+foreach (var step in metadata.MeshPipeline)
+{
+    var resolvedArgs = ResolvePipelineTokens(step.Args, caseDir, metadata);
+    Console.WriteLine($"Running {step.Command}...");
+
+    ProcessResult stepResult;
+    if (step.Parallel && cores > 1)
+    {
+        stepResult = _processExecutor.Execute("mpirun", $"-np {cores} {step.Command} {resolvedArgs} -parallel");
+    }
+    else
+    {
+        stepResult = _processExecutor.Execute(step.Command, resolvedArgs);
+    }
+
+    if (stepResult.ExitCode != 0)
+    {
+        if (step.Optional)
+        {
+            result.Warnings.Add($"{step.Command} failed (optional step)");
+            _loggingService.LogError($"{step.Command} failed: {stepResult.Output}");
+        }
+        else
+        {
+            result.Success = false;
+            result.ErrorMessage = $"{step.Command} failed with exit code {stepResult.ExitCode}";
+            return result;
+        }
+    }
+    else
+    {
+        Console.WriteLine($"✓ {step.Command} completed successfully");
+    }
+}
+```
+
+**Step 3: Implement token resolver**
+
+```csharp
+private string ResolvePipelineTokens(string args, string caseDir, TemplateMetadata metadata)
+{
+    var geometryStlPath = Path.Combine(caseDir, "constant", "triSurface", metadata.Geometry.StlName);
+    var outsidePoint = metadata.Geometry.SurfaceOrient?.OutsidePoint is { } pt
+        ? $"{pt[0]} {pt[1]} {pt[2]}"
+        : "0 0 0";
+
+    return args
+        .Replace("{caseDir}", caseDir)
+        .Replace("{geometryStlPath}", geometryStlPath)
+        .Replace("{outsidePoint}", outsidePoint);
+}
+```
+
+**Step 4: Remove hardcoded surfaceOrient, PatchBoundaryForAMI guard**
+
+- Delete the surfaceOrient block (lines 73-92)
+- Guard `PatchBoundaryForAMI` with `metadata.Rotation.Enabled`
+- Delete the `DistributeTriSurface` hardcoded file list — derive from metadata
+
+**Step 5: Run tests**
+
+Run: `dotnet test`
+Expected: all pass
+
+**Step 6: Commit**
+
+```bash
+git add Services/MeshService.cs foamscript.Tests/Services/MeshServiceTests.cs
+git commit -m "feat: generic mesh pipeline executor driven by TEMPLATE.json
+
+Replaces hardcoded blockMesh→surfaceOrient→snappy sequence.
+Each template declares its own mesh steps in meshPipeline."
+```
+
+---
+
+## Task 5: Generic Solve Pipeline Executor
+
+**Files:**
+- Modify: `Services/SolverService.cs`
+- Test: `foamscript.Tests/Services/SolverServiceTests.cs`
+
+**Step 1: Write failing test**
+
+```csharp
+[Fact]
+public void SolveCase_ExecutesSolvePipelineFromMetadata()
+{
+    // Setup: metadata with solvePipeline = [decomposePar, simpleFoam(parallel), reconstructPar]
+    // Verify: each step executed in order
+}
+```
+
+**Step 2: Implement generic solver pipeline**
+
+Same pattern as mesh — read `metadata.SolvePipeline`, execute each step with token resolution. Replace the hardcoded decomposePar → solver → reconstructPar sequence.
+
+**Step 3: Run tests, commit**
+
+```bash
+git commit -m "feat: generic solve pipeline executor driven by TEMPLATE.json"
+```
+
+---
+
+## Task 6: Generic Results Extraction
+
+**Files:**
+- Modify: `Services/SolverService.cs` (ParseForceCoeffs)
+- Modify: `Services/ResultsService.cs`
+- Modify: `Services/ReportService.cs` (CSV export)
+- Test: `foamscript.Tests/Services/ResultsServiceTests.cs`
+
+**Step 1: Write failing test for generic column extraction**
+
+```csharp
+[Fact]
+public void ExtractResults_UsesMetadataColumns()
+{
+    // Setup: metadata with results.columns = { "Cd": 1, "Cl": 4 }
+    // Verify: extracted results contain Cd and Cl keys with correct values
+}
+```
+
+**Step 2: Refactor results to use Dictionary<string, double> instead of fixed Cd/Cl/Cm**
+
+The `CaseResult` model gets a `Dictionary<string, double?> Coefficients` property instead of separate `Cd`, `Cl`, `CmPitch` properties. The dictionary keys come from `metadata.Results.Columns`.
+
+**Step 3: Update CSV export**
+
+`WriteCoefficientCsv` in ReportService generates headers dynamically from the results column names instead of hardcoded `"AoA_deg,Cd,Cl,CmPitch,L_over_D,Converged"`.
+
+**Step 4: Run tests, commit**
+
+```bash
+git commit -m "feat: generic results extraction using metadata column mapping
+
+Results keys are now dynamic from TEMPLATE.json results.columns.
+CSV export generates headers from metadata."
+```
+
+---
+
+## Task 7: Template-Driven Report Generation
+
+**Files:**
+- Modify: `Services/ReportService.cs`
+- Modify: `Services/HtmlReportGenerator.cs`
+- Modify: `Services/PdfReportGenerator.cs`
+- Modify: `Services/ChartGenerator.cs`
+- Create: `Templates/external_disc_rotatingwall_steady/report/report.html` (copy from `Templates/report/report.html`)
+- Create: `Templates/external_airfoil_static_steady/report/report.html` (copy initially, diverge later)
+- Test: `foamscript.Tests/Services/ReportServiceTests.cs`
+
+**Step 1: Copy existing report template into disc template directory**
+
+```bash
+mkdir -p Templates/external_disc_rotatingwall_steady/report
+cp Templates/report/report.html Templates/external_disc_rotatingwall_steady/report/
+# Same for AMI transient
+mkdir -p Templates/external_disc_rotating-ami_transient/report
+cp Templates/report/report.html Templates/external_disc_rotating-ami_transient/report/
+# Same for airfoil (will diverge later)
+mkdir -p Templates/external_airfoil_static_steady/report
+cp Templates/report/report.html Templates/external_airfoil_static_steady/report/
+```
+
+**Step 2: Update HtmlReportGenerator to find template-specific report.html**
+
+Change `FindTemplatePath()` to first look in the template directory (from study.json manifest), then fall back to the global `Templates/report/report.html`.
+
+**Step 3: Make chart generation data-driven**
+
+`ChartGenerator` already has a generic `GeneratePolarChartSvg(results, fieldName)` method. The `ReportService` needs to iterate over `metadata.Results.Columns` keys to generate one chart per coefficient instead of hardcoding Cl/Cd/Cm/LD charts.
+
+**Step 4: Update PdfReportGenerator coefficient table**
+
+Replace hardcoded headers at line 349 (`"Cᴅ"`, `"Cₗ"`, `"Cm,pitch"`) with dynamic headers from the results columns.
+
+**Step 5: Remove Python visualization scripts**
+
+Delete `Templates/report/extract_slice.py` and `Templates/report/render_slice.py`. Replace with OpenFOAM `postProcess` declarations in TEMPLATE.json and ScottPlot rendering in C#.
+
+Note: This is the most complex sub-task and may need to be split further during execution. The Python elimination can be deferred to a follow-up if it blocks progress.
+
+**Step 6: Run tests, commit**
+
+```bash
+git commit -m "feat: template-driven report generation
+
+Each template ships its own report/report.html Scriban template.
+Charts generated dynamically from results.columns metadata.
+PDF coefficient table headers are data-driven."
+```
+
+---
+
+## Task 8: Update Existing Callers and Clean Up
+
+**Files:**
+- Modify: `Services/CaseService.cs` — remove `disc_diameter` alias, update parameter names
+- Modify: `Services/DomainService.cs` — rename `discStlFile` parameter
+- Modify: `Handlers/ListTemplatesHandler.cs` — display expanded metadata
+- Modify: `Services/ReportService.cs` — remove RPM display when rotation.enabled=false
+- Delete: `Templates/report/extract_slice.py` (moved to postProcess)
+- Delete: `Templates/report/render_slice.py` (moved to postProcess)
+
+**Step 1: Clean up backward-compat aliases**
+
+In `CaseService.CalculateTemplateContext()`:
+- Remove `disc_diameter = refLength` alias (line 320)
+- Existing templates already use `ref_length`
+
+**Step 2: Rename misleading parameters**
+
+In `DomainService`:
+- Rename any `discStlFile` parameters to `geometryStlFile`
+
+**Step 3: Conditional RPM display**
+
+In report generators:
+- Only show RPM row when `metadata.Rotation.Enabled == true`
+
+**Step 4: Run full test suite**
+
+Run: `dotnet test`
+Expected: all 211+ tests pass, 0 warnings
+
+**Step 5: Commit**
+
+```bash
+git commit -m "chore: clean up disc-specific naming and conditional displays
+
+Removes disc_diameter alias, renames discStlFile, conditionally
+shows RPM in reports based on rotation.enabled."
+```
+
+---
+
+## Task 9: Build, Full Test, E2E Validation
+
+**Step 1: Build**
+
+Run: `dotnet build --configuration Release`
+Expected: 0 warnings, 0 errors
+
+**Step 2: Run full test suite**
+
+Run: `dotnet test`
+Expected: all tests pass
+
+**Step 3: Push to Linux, E2E validate disc template**
+
+Verify the disc template still produces identical results to pre-refactor:
+```bash
+foamscript new-study --template external_disc_rotatingwall_steady --project-name disc_regression --output-dir /run --model-source Apogee.step --velocity 27 --rpm 925 --angles 0
+foamscript mesh -d /run/disc_regression
+foamscript solve -d /run/disc_regression
+foamscript report -d /run/disc_regression
+```
+
+**Step 4: E2E validate airfoil template**
+
+```bash
+foamscript new-study --template external_airfoil_static_steady --project-name airfoil_regression --output-dir /run --model-source NACA0012.stl --velocity 26 --angles 0 --refinement-min 3 --refinement-max 4
+foamscript mesh -d /run/airfoil_regression
+foamscript solve -d /run/airfoil_regression
+foamscript report -d /run/airfoil_regression
+```
+
+**Step 5: Commit final state, update docs**
+
+```bash
+git commit -m "chore: template generalization complete — all E2E tests pass"
+```
+
+Update `Docs/ExecutiveSummary.md` with new template count, test count, and architecture changes.
+
+---
+
+## Task Summary
+
+| Task | Description | Est. Complexity |
+|------|-------------|----------------|
+| 1 | Expand TemplateMetadata model + remove disc fallback | Medium |
+| 2 | Update all TEMPLATE.json files to new schema | Low |
+| 3 | CLI parameter generalization (--template required, nullable params) | Medium |
+| 4 | Generic mesh pipeline executor | High |
+| 5 | Generic solve pipeline executor | Medium |
+| 6 | Generic results extraction | Medium |
+| 7 | Template-driven report generation + Python elimination | High |
+| 8 | Clean up backward-compat aliases and cosmetic issues | Low |
+| 9 | Build, test, E2E validation on Linux | Medium |
+
+**Total: 9 tasks, ~15-25 commits**
+
+## Dependencies
+
+```
+Task 1 (model) ──→ Task 2 (JSON files) ──→ Task 3 (CLI)
+                                         ──→ Task 4 (mesh pipeline)
+                                         ──→ Task 5 (solve pipeline)
+                                         ──→ Task 6 (results)
+                                         ──→ Task 7 (report)
+Tasks 3-7 ──→ Task 8 (cleanup) ──→ Task 9 (E2E)
+```
+
+Tasks 3-7 can be parallelized across agents since they touch different services.

--- a/Handlers/NewStudyHandler.cs
+++ b/Handlers/NewStudyHandler.cs
@@ -8,11 +8,13 @@ namespace foamscript.Handlers
     {
         private readonly LoggingService _loggingService;
         private readonly CaseService _caseService;
+        private readonly TemplateMetadataService _metadataService;
 
-        public NewStudyHandler(LoggingService loggingService, CaseService caseService)
+        public NewStudyHandler(LoggingService loggingService, CaseService caseService, TemplateMetadataService metadataService)
         {
             _loggingService = loggingService;
             _caseService = caseService;
+            _metadataService = metadataService;
         }
 
         public int Handle(NewStudyModel model)
@@ -34,6 +36,7 @@ namespace foamscript.Handlers
             {
                 // Validate required CLI args
                 var missing = new List<string>();
+                if (string.IsNullOrEmpty(model.TemplatePath)) missing.Add("--template (-t)");
                 if (string.IsNullOrEmpty(model.ProjectName)) missing.Add("--project-name (-n)");
                 if (string.IsNullOrEmpty(model.OutputDir)) missing.Add("--output-dir (-o)");
                 if (string.IsNullOrEmpty(model.ModelSource)) missing.Add("--model-source (-s)");
@@ -56,8 +59,8 @@ namespace foamscript.Handlers
                     TemplateName = model.TemplatePath,
                     ModelSource = model.ModelSource,
                     Angles = model.Angles,
-                    Velocity = model.Velocity,
-                    Rpm = model.Rpm,
+                    Velocity = model.Velocity ?? 0,
+                    Rpm = model.Rpm ?? 0,
                     InputUnits = model.InputUnits,
                     MeshSize = model.MeshSize,
                     FeatureAngle = model.FeatureAngle,
@@ -129,6 +132,61 @@ namespace foamscript.Handlers
                 Console.WriteLine();
                 Console.WriteLine("Use 'foamscript list-templates' for more information");
                 return -1;
+            }
+
+            // Validate template-required parameters (only for CLI args, not JSON config)
+            if (model.ConfigFile == null)
+            {
+                try
+                {
+                    var metadata = _metadataService.LoadMetadata(templatePath);
+                    var templateErrors = new List<string>();
+
+                    foreach (var (paramName, paramDef) in metadata.Parameters)
+                    {
+                        if (paramDef.Required)
+                        {
+                            var isMissing = paramName.ToLowerInvariant() switch
+                            {
+                                "velocity" => model.Velocity == null,
+                                "rpm" => model.Rpm == null,
+                                "angles" => string.IsNullOrEmpty(model.Angles),
+                                _ => false
+                            };
+
+                            if (isMissing)
+                            {
+                                templateErrors.Add($"Template '{metadata.Name}' requires --{paramName} but it was not provided");
+                            }
+                        }
+                        else if (paramDef.Default != null)
+                        {
+                            // Apply template defaults for optional parameters when CLI value is null
+                            switch (paramName.ToLowerInvariant())
+                            {
+                                case "velocity" when model.Velocity == null:
+                                    config.Velocity = Convert.ToDouble(paramDef.Default);
+                                    break;
+                                case "rpm" when model.Rpm == null:
+                                    config.Rpm = Convert.ToDouble(paramDef.Default);
+                                    break;
+                            }
+                        }
+                    }
+
+                    if (templateErrors.Count > 0)
+                    {
+                        Console.WriteLine("✗ Missing required template parameters:");
+                        foreach (var err in templateErrors)
+                            Console.WriteLine($"    {err}");
+                        Console.WriteLine();
+                        return -1;
+                    }
+                }
+                catch (FileNotFoundException)
+                {
+                    // Template has no TEMPLATE.json — skip parameter validation
+                }
             }
 
             _loggingService.LogInformation($"Creating project '{config.ProjectName}' in {config.OutputDir}");
@@ -251,7 +309,7 @@ namespace foamscript.Handlers
         {
             var templatesDir = ListTemplatesHandler.GetTemplatesDirectory();
 
-            // If null or empty, use default
+            // If null or empty, use default (JSON config path may not specify template)
             if (string.IsNullOrEmpty(templatePathOrName))
             {
                 return Path.Combine(templatesDir, "external_disc_rotatingwall_steady");

--- a/Models/NewStudyModel.cs
+++ b/Models/NewStudyModel.cs
@@ -30,14 +30,14 @@ namespace foamscript.Models
 
         // ── Optional study inputs (with sensible defaults) ────────────────────
 
-        [Option('t', "template", Required = false, HelpText = "Template name or path (defaults to external_disc_rotatingwall_steady)")]
+        [Option('t', "template", Required = false, HelpText = "Template name or path (required — use 'foamscript list-templates' to see available templates)")]
         public string? TemplatePath { get; set; }
 
-        [Option('v', "velocity", Required = false, Default = 27.0, HelpText = "Free stream velocity magnitude (m/s, default: 27.0 — elite amateur throw speed)")]
-        public double Velocity { get; set; } = 27.0;
+        [Option('v', "velocity", Required = false, HelpText = "Freestream velocity magnitude (m/s)")]
+        public double? Velocity { get; set; }
 
-        [Option('r', "rpm", Required = false, Default = 925.0, HelpText = "Disc rotation speed (RPM, default: 925 — elite amateur spin rate)")]
-        public double Rpm { get; set; } = 925.0;
+        [Option('r', "rpm", Required = false, HelpText = "Rotational speed (RPM)")]
+        public double? Rpm { get; set; }
 
         [Option('u', "input-units", Required = false, Default = "mm", HelpText = "Source file units (mm, cm, m, in, ft). Only used for STEP/IGES conversion. Default: mm")]
         public string InputUnits { get; set; } = "mm";
@@ -79,19 +79,19 @@ namespace foamscript.Models
 
         // ── Domain geometry parameters ────────────────────────────────────────
 
-        [Option("rotor-radius-scale", Required = false, Default = 1.25, HelpText = "Rotor AMI cylinder radius as a multiple of disc radius (default: 1.25)")]
+        [Option("rotor-radius-scale", Required = false, Default = 1.25, HelpText = "Rotor AMI cylinder radius as a multiple of geometry radius (default: 1.25)")]
         public double RotorRadiusScale { get; set; } = 1.25;
 
-        [Option("rotor-height-scale", Required = false, Default = 1.5, HelpText = "Rotor AMI cylinder height as a multiple of disc height (default: 1.5)")]
+        [Option("rotor-height-scale", Required = false, Default = 1.5, HelpText = "Rotor AMI cylinder height as a multiple of geometry height (default: 1.5)")]
         public double RotorHeightScale { get; set; } = 1.5;
 
-        [Option("tunnel-upstream", Required = false, Default = 5.0, HelpText = "Wind tunnel upstream extent in disc diameters (default: 5.0)")]
+        [Option("tunnel-upstream", Required = false, Default = 5.0, HelpText = "Wind tunnel upstream extent in reference lengths (default: 5.0)")]
         public double TunnelUpstream { get; set; } = 5.0;
 
-        [Option("tunnel-downstream", Required = false, Default = 10.0, HelpText = "Wind tunnel downstream extent in disc diameters (default: 10.0)")]
+        [Option("tunnel-downstream", Required = false, Default = 10.0, HelpText = "Wind tunnel downstream extent in reference lengths (default: 10.0)")]
         public double TunnelDownstream { get; set; } = 10.0;
 
-        [Option("tunnel-radial", Required = false, Default = 5.0, HelpText = "Wind tunnel radial extent in disc diameters (default: 5.0)")]
+        [Option("tunnel-radial", Required = false, Default = 5.0, HelpText = "Wind tunnel radial extent in reference lengths (default: 5.0)")]
         public double TunnelRadial { get; set; } = 5.0;
 
         [Option("mesh-resolution", Required = false, Default = 32, HelpText = "Number of vertices around generated cylinder geometries (default: 32)")]

--- a/Models/ResultsSummary.cs
+++ b/Models/ResultsSummary.cs
@@ -13,14 +13,36 @@ namespace foamscript.Models
 
     /// <summary>
     /// Extracted force coefficients for a single case.
+    /// Generic storage via Coefficients dictionary; Cd/Cl/CmPitch are backward-compat accessors.
     /// </summary>
     public class CaseResult
     {
         public string CaseName { get; set; } = string.Empty;
         public double AngleOfAttack { get; set; }
-        public double? Cd { get; set; }
-        public double? Cl { get; set; }
-        public double? CmPitch { get; set; }
+
+        /// <summary>
+        /// Generic coefficient storage — keys come from TEMPLATE.json results.columns.
+        /// This is the primary data store; Cd/Cl/CmPitch are convenience accessors.
+        /// </summary>
+        public Dictionary<string, double?> Coefficients { get; set; } = new();
+
+        // Backward-compat accessors — read/write through Coefficients dictionary
+        public double? Cd
+        {
+            get => Coefficients.TryGetValue("Cd", out var v) ? v : null;
+            set => Coefficients["Cd"] = value;
+        }
+        public double? Cl
+        {
+            get => Coefficients.TryGetValue("Cl", out var v) ? v : null;
+            set => Coefficients["Cl"] = value;
+        }
+        public double? CmPitch
+        {
+            get => Coefficients.TryGetValue("CmPitch", out var v) ? v : null;
+            set => Coefficients["CmPitch"] = value;
+        }
+
         public bool Converged { get; set; }
         public string? ErrorMessage { get; set; }
     }

--- a/Models/StudyConfig.cs
+++ b/Models/StudyConfig.cs
@@ -53,23 +53,23 @@ namespace foamscript.Models
 
     /// <summary>
     /// Domain geometry parameters controlling rotor zone and wind tunnel sizing.
-    /// All scales are relative to the detected disc diameter.
+    /// All scales are relative to the detected reference dimension.
     /// </summary>
     public class StudyDomainConfig
     {
-        /// <summary>Rotor AMI cylinder radius as a multiple of disc radius. Default: 1.25 (~25% clearance).</summary>
+        /// <summary>Rotor AMI cylinder radius as a multiple of geometry radius. Default: 1.25 (~25% clearance).</summary>
         public double RotorRadiusScale { get; set; } = 1.25;
 
-        /// <summary>Rotor AMI cylinder height as a multiple of disc height. Default: 1.5.</summary>
+        /// <summary>Rotor AMI cylinder height as a multiple of geometry height. Default: 1.5.</summary>
         public double RotorHeightScale { get; set; } = 1.5;
 
-        /// <summary>Wind tunnel upstream extent in disc diameters. Default: 5.0 (CFD convention).</summary>
+        /// <summary>Wind tunnel upstream extent in reference lengths. Default: 5.0 (CFD convention).</summary>
         public double TunnelUpstream { get; set; } = 5.0;
 
-        /// <summary>Wind tunnel downstream extent in disc diameters. Default: 10.0 (CFD convention).</summary>
+        /// <summary>Wind tunnel downstream extent in reference lengths. Default: 10.0 (CFD convention).</summary>
         public double TunnelDownstream { get; set; } = 10.0;
 
-        /// <summary>Wind tunnel radial extent in disc diameters. Default: 5.0 (CFD convention).</summary>
+        /// <summary>Wind tunnel radial extent in reference lengths. Default: 5.0 (CFD convention).</summary>
         public double TunnelRadial { get; set; } = 5.0;
 
         /// <summary>Number of vertices around the generated cylinder geometries. Default: 32.</summary>

--- a/Models/TemplateMetadata.cs
+++ b/Models/TemplateMetadata.cs
@@ -69,7 +69,13 @@ namespace foamscript.Models
         public string[] RequiredStlFiles { get; set; } = [];
 
         [JsonPropertyName("surfaceOrient")]
-        public string? SurfaceOrient { get; set; }
+        public SurfaceOrientConfig? SurfaceOrient { get; set; }
+    }
+
+    public class SurfaceOrientConfig
+    {
+        [JsonPropertyName("outsidePoint")]
+        public double[] OutsidePoint { get; set; } = [];
     }
 
     public class ReferenceConfig

--- a/Models/TemplateMetadata.cs
+++ b/Models/TemplateMetadata.cs
@@ -133,6 +133,9 @@ namespace foamscript.Models
 
         [JsonPropertyName("optional")]
         public bool Optional { get; set; }
+
+        [JsonPropertyName("parallelOnly")]
+        public bool ParallelOnly { get; set; }
     }
 
     public class ResultsConfig

--- a/Models/TemplateMetadata.cs
+++ b/Models/TemplateMetadata.cs
@@ -4,7 +4,7 @@ namespace foamscript.Models
 {
     /// <summary>
     /// Machine-readable metadata for an OpenFOAM template, loaded from TEMPLATE.json.
-    /// Drives geometry handling, reference dimension extraction, and domain generation.
+    /// Drives geometry handling, reference dimension extraction, pipeline execution, and reporting.
     /// </summary>
     public class TemplateMetadata
     {
@@ -17,26 +17,140 @@ namespace foamscript.Models
         [JsonPropertyName("solver")]
         public string Solver { get; set; } = "simpleFoam";
 
-        [JsonPropertyName("geometryType")]
-        public string GeometryType { get; set; } = "disc";
+        [JsonPropertyName("geometry")]
+        public GeometryConfig Geometry { get; set; } = new();
 
-        [JsonPropertyName("geometryStlName")]
-        public string GeometryStlName { get; set; } = "disc.stl";
+        [JsonPropertyName("reference")]
+        public ReferenceConfig Reference { get; set; } = new();
 
-        [JsonPropertyName("referenceDimension")]
-        public string ReferenceDimension { get; set; } = "diameter";
-
-        [JsonPropertyName("referenceAreaFormula")]
-        public string ReferenceAreaFormula { get; set; } = "circular";
-
-        [JsonPropertyName("requiresRotorZone")]
-        public bool RequiresRotorZone { get; set; } = true;
-
-        [JsonPropertyName("requiredStlFiles")]
-        public string[] RequiredStlFiles { get; set; } = ["disc.stl", "tunnel.stl"];
+        [JsonPropertyName("rotation")]
+        public RotationConfig Rotation { get; set; } = new();
 
         [JsonPropertyName("validation")]
         public GeometryValidation? Validation { get; set; }
+
+        [JsonPropertyName("parameters")]
+        public Dictionary<string, ParameterDef> Parameters { get; set; } = new();
+
+        [JsonPropertyName("domain")]
+        public DomainConfig Domain { get; set; } = new();
+
+        [JsonPropertyName("meshPipeline")]
+        public List<PipelineStep> MeshPipeline { get; set; } = new();
+
+        [JsonPropertyName("solvePipeline")]
+        public List<PipelineStep> SolvePipeline { get; set; } = new();
+
+        [JsonPropertyName("results")]
+        public ResultsConfig Results { get; set; } = new();
+
+        [JsonPropertyName("report")]
+        public ReportConfig Report { get; set; } = new();
+
+        // Backward-compatibility accessors — allows existing code to keep working
+        // while we migrate callers to the nested schema.
+        [JsonIgnore] public string GeometryType => Geometry.Type;
+        [JsonIgnore] public string GeometryStlName => Geometry.StlName;
+        [JsonIgnore] public string ReferenceDimension => Reference.Dimension;
+        [JsonIgnore] public string ReferenceAreaFormula => Reference.AreaFormula;
+        [JsonIgnore] public bool RequiresRotorZone => Rotation.RequiresRotorZone;
+        [JsonIgnore] public string[] RequiredStlFiles => Geometry.RequiredStlFiles;
+    }
+
+    public class GeometryConfig
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("stlName")]
+        public string StlName { get; set; } = string.Empty;
+
+        [JsonPropertyName("requiredStlFiles")]
+        public string[] RequiredStlFiles { get; set; } = [];
+
+        [JsonPropertyName("surfaceOrient")]
+        public string? SurfaceOrient { get; set; }
+    }
+
+    public class ReferenceConfig
+    {
+        [JsonPropertyName("dimension")]
+        public string Dimension { get; set; } = string.Empty;
+
+        [JsonPropertyName("areaFormula")]
+        public string AreaFormula { get; set; } = string.Empty;
+    }
+
+    public class RotationConfig
+    {
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        [JsonPropertyName("requiresRotorZone")]
+        public bool RequiresRotorZone { get; set; }
+    }
+
+    public class ParameterDef
+    {
+        [JsonPropertyName("required")]
+        public bool Required { get; set; }
+
+        [JsonPropertyName("default")]
+        public object? Default { get; set; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+    }
+
+    public class DomainConfig
+    {
+        [JsonPropertyName("upstream")]
+        public double Upstream { get; set; }
+
+        [JsonPropertyName("downstream")]
+        public double Downstream { get; set; }
+
+        [JsonPropertyName("radial")]
+        public double Radial { get; set; }
+    }
+
+    public class PipelineStep
+    {
+        [JsonPropertyName("command")]
+        public string Command { get; set; } = string.Empty;
+
+        [JsonPropertyName("args")]
+        public string Args { get; set; } = string.Empty;
+
+        [JsonPropertyName("parallel")]
+        public bool Parallel { get; set; }
+
+        [JsonPropertyName("optional")]
+        public bool Optional { get; set; }
+    }
+
+    public class ResultsConfig
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("dataFile")]
+        public string DataFile { get; set; } = string.Empty;
+
+        [JsonPropertyName("columns")]
+        public Dictionary<string, int> Columns { get; set; } = new();
+    }
+
+    public class ReportConfig
+    {
+        [JsonPropertyName("template")]
+        public string Template { get; set; } = string.Empty;
+
+        [JsonPropertyName("standard")]
+        public string Standard { get; set; } = string.Empty;
+
+        [JsonPropertyName("postProcess")]
+        public List<string> PostProcess { get; set; } = new();
     }
 
     /// <summary>

--- a/Services/DomainService.cs
+++ b/Services/DomainService.cs
@@ -21,7 +21,7 @@ namespace foamscript.Services
         /// Validation (e.g., PDGA size checks) is the caller's responsibility via TemplateMetadata.
         /// </summary>
         public DomainGenerationResult GenerateDomain(
-            string discStlFile,
+            string geometryStlFile,
             string outputDirectory,
             double rotorRadiusScale,
             double rotorHeightScale,
@@ -33,21 +33,21 @@ namespace foamscript.Services
             var result = new DomainGenerationResult();
 
             // Check if STL exists
-            var fileCheckResult = _processExecutor.Execute("test", $"-f {discStlFile}");
+            var fileCheckResult = _processExecutor.Execute("test", $"-f {geometryStlFile}");
             if (fileCheckResult.ExitCode != 0)
             {
                 result.IsSuccess = false;
-                result.ErrorMessage = $"Disc STL file not found: {discStlFile}";
+                result.ErrorMessage = $"Geometry STL file not found: {geometryStlFile}";
                 return result;
             }
 
             // Parse STL and calculate bounding box
             // STL file is assumed to be in meters (converted by the convert command with --input-units)
-            var boundingBox = CalculateBoundingBox(discStlFile);
+            var boundingBox = CalculateBoundingBox(geometryStlFile);
             if (boundingBox == null)
             {
                 result.IsSuccess = false;
-                result.ErrorMessage = $"Failed to parse disc STL file: {discStlFile}";
+                result.ErrorMessage = $"Failed to parse geometry STL file: {geometryStlFile}";
                 return result;
             }
 

--- a/Services/GeometryService.cs
+++ b/Services/GeometryService.cs
@@ -23,7 +23,7 @@ namespace foamscript.Services
             => _conversionService.ValidateStl(stlFile);
 
         public DomainGenerationResult GenerateDomain(
-            string discStlFile,
+            string geometryStlFile,
             string outputDirectory,
             double rotorRadiusScale,
             double rotorHeightScale,
@@ -31,7 +31,7 @@ namespace foamscript.Services
             double tunnelDownstream,
             double tunnelRadial,
             int meshResolution)
-            => _domainService.GenerateDomain(discStlFile, outputDirectory, rotorRadiusScale, rotorHeightScale, tunnelUpstream, tunnelDownstream, tunnelRadial, meshResolution);
+            => _domainService.GenerateDomain(geometryStlFile, outputDirectory, rotorRadiusScale, rotorHeightScale, tunnelUpstream, tunnelDownstream, tunnelRadial, meshResolution);
 
         public DomainGenerationResult GenerateTunnelOnly(
             string stlFile,

--- a/Services/HtmlReportGenerator.cs
+++ b/Services/HtmlReportGenerator.cs
@@ -12,10 +12,11 @@ namespace foamscript.Services
     {
         /// <summary>
         /// Renders the HTML report template with chart data and returns the HTML string.
+        /// Looks for per-template report.html first, then falls back to global.
         /// </summary>
         public string GenerateReport(ReportData data)
         {
-            var templatePath = FindTemplatePath();
+            var templatePath = FindTemplatePath(data.TemplateName);
             var templateContent = File.ReadAllText(templatePath);
 
             var template = Template.Parse(templateContent);
@@ -46,17 +47,36 @@ namespace foamscript.Services
             File.WriteAllText(outputPath, html);
         }
 
-        private static string FindTemplatePath()
+        /// <summary>
+        /// Finds the report template HTML file. Searches template-specific directory first
+        /// (e.g., Templates/{templateName}/report/report.html), then falls back to global
+        /// Templates/report/report.html. This allows each template to ship its own report layout.
+        /// </summary>
+        internal static string FindTemplatePath(string? templateName = null)
         {
-            // Check relative to executable
             var exeDir = AppDomain.CurrentDomain.BaseDirectory;
-            var candidates = new[]
+            var candidates = new List<string>();
+
+            // Template-specific paths first (if template name is known)
+            if (!string.IsNullOrEmpty(templateName))
+            {
+                candidates.AddRange(new[]
+                {
+                    Path.Combine(exeDir, "Templates", templateName, "report", "report.html"),
+                    Path.Combine(exeDir, "..", "Templates", templateName, "report", "report.html"),
+                    Path.Combine(exeDir, "..", "..", "..", "Templates", templateName, "report", "report.html"),
+                    Path.Combine(exeDir, "..", "..", "..", "..", "Templates", templateName, "report", "report.html"),
+                });
+            }
+
+            // Fall back to global report template
+            candidates.AddRange(new[]
             {
                 Path.Combine(exeDir, "Templates", "report", "report.html"),
                 Path.Combine(exeDir, "..", "Templates", "report", "report.html"),
                 Path.Combine(exeDir, "..", "..", "..", "Templates", "report", "report.html"),
                 Path.Combine(exeDir, "..", "..", "..", "..", "Templates", "report", "report.html"),
-            };
+            });
 
             foreach (var candidate in candidates)
             {
@@ -66,7 +86,7 @@ namespace foamscript.Services
             }
 
             throw new FileNotFoundException(
-                "Could not find report template. Expected at Templates/report/report.html relative to executable.");
+                "Could not find report template. Expected at Templates/{template}/report/report.html or Templates/report/report.html relative to executable.");
         }
 
         private static string ConvertToSnakeCase(string name)
@@ -101,11 +121,18 @@ namespace foamscript.Services
         public List<MeshStatEntry> MeshStats { get; set; } = new();
 
         // Charts (SVG strings for HTML, PNG bytes for PDF)
+        // Legacy fixed chart properties — kept for backward compat with existing report.html templates
         public string ClVsAoaChart { get; set; } = string.Empty;
         public string CdVsAoaChart { get; set; } = string.Empty;
         public string CmVsAoaChart { get; set; } = string.Empty;
         public string LdVsAoaChart { get; set; } = string.Empty;
         public string DragPolarChart { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Dynamic chart list — one SVG chart per coefficient from TEMPLATE.json results.columns.
+        /// New report templates should use this instead of the fixed chart properties above.
+        /// </summary>
+        public List<ChartEntry> CoefficientCharts { get; set; } = new();
 
         // Case results table
         public List<CaseResultEntry> Cases { get; set; } = new();
@@ -142,6 +169,16 @@ namespace foamscript.Services
     public class ConvergenceChartEntry
     {
         public string CaseName { get; set; } = string.Empty;
+        public string Chart { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// A named chart entry for dynamic report generation.
+    /// </summary>
+    public class ChartEntry
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
         public string Chart { get; set; } = string.Empty;
     }
 }

--- a/Services/MeshService.cs
+++ b/Services/MeshService.cs
@@ -9,16 +9,18 @@ namespace foamscript.Services
         private readonly ILogger<LoggingService> _logger;
         private readonly IProcessExecutor _processExecutor;
         private readonly LoggingService _loggingService;
+        private readonly TemplateMetadataService _metadataService;
 
-        public MeshService(ILogger<LoggingService> logger, IProcessExecutor processExecutor, LoggingService loggingService)
+        public MeshService(ILogger<LoggingService> logger, IProcessExecutor processExecutor, LoggingService loggingService, TemplateMetadataService metadataService)
         {
             _logger = logger;
             _processExecutor = processExecutor;
             _loggingService = loggingService;
+            _metadataService = metadataService;
         }
 
         /// <summary>
-        /// Meshes an OpenFOAM case using blockMesh and snappyHexMesh.
+        /// Meshes an OpenFOAM case using a template-driven pipeline from TEMPLATE.json.
         /// </summary>
         public virtual MeshResult MeshCase(string caseDir, bool parallel, int cores, bool checkQuality, bool overwrite)
         {
@@ -48,191 +50,86 @@ namespace foamscript.Services
                     return result;
                 }
 
-                // Step 1: Run blockMesh
-                Console.WriteLine("Running blockMesh...");
-                var blockMeshResult = _processExecutor.Execute("blockMesh", $"-case {caseDir}");
+                // Load template metadata for pipeline definition
+                var metadata = _metadataService.LoadMetadata(caseDir);
 
-                if (blockMeshResult.ExitCode != 0)
+                // Execute mesh pipeline from TEMPLATE.json
+                foreach (var step in metadata.MeshPipeline)
                 {
-                    result.IsSuccess = false;
-                    result.ErrorMessage = $"blockMesh failed with exit code {blockMeshResult.ExitCode}";
+                    // Skip parallel-only steps (decomposePar, reconstructParMesh) in serial mode
+                    if (step.ParallelOnly && !parallel)
+                        continue;
 
-                    // Log detailed error output to file
-                    _loggingService.LogError($"blockMesh failed with exit code {blockMeshResult.ExitCode}");
-                    _loggingService.LogError($"blockMesh stdout:\n{blockMeshResult.Output}");
-                    if (!string.IsNullOrEmpty(blockMeshResult.Error))
+                    // Skip checkMesh if quality checking is not requested
+                    if (step.Command == "checkMesh" && !checkQuality)
+                        continue;
+
+                    var resolvedArgs = ResolvePipelineTokens(step.Args, caseDir, metadata);
+                    Console.WriteLine($"Running {step.Command}...");
+
+                    ProcessResult stepResult;
+                    if (step.Parallel && cores > 1)
                     {
-                        _loggingService.LogError($"blockMesh stderr:\n{blockMeshResult.Error}");
-                    }
-
-                    return result;
-                }
-
-                Console.WriteLine("✓ blockMesh completed successfully");
-
-                // Step 1.5: Orient disc STL normals outward.
-                // gmsh preserves BREP face orientation from STEP files. Shapr3D's Parasolid
-                // kernel may produce inward-facing normals, which causes snappyHexMesh to
-                // create boundary faces with reversed area vectors → all force coefficient
-                // signs flip. surfaceOrient uses a known-outside point (0,0,-1) — below
-                // the disc — to determine outward direction, then reorients all normals.
-                Console.WriteLine("Orienting disc surface normals...");
-                var discStl = Path.Combine(caseDir, "constant", "triSurface", "disc.stl");
-                var orientResult = _processExecutor.Execute("surfaceOrient",
-                    $"{discStl} \"(0 0 -1)\" {discStl}");
-
-                if (orientResult.ExitCode != 0)
-                {
-                    result.Warnings.Add("surfaceOrient failed — disc normals may be incorrect");
-                    _loggingService.LogError($"surfaceOrient failed: {orientResult.Output}");
-                }
-                else
-                {
-                    Console.WriteLine("✓ Disc surface normals oriented outward");
-                }
-
-                // Step 2: Extract surface features (generates .eMesh files for snappyHexMesh)
-                Console.WriteLine("Extracting surface features...");
-                var featureResult = _processExecutor.Execute("surfaceFeatureExtract", $"-case {caseDir}");
-
-                if (featureResult.ExitCode != 0)
-                {
-                    result.IsSuccess = false;
-                    result.ErrorMessage = $"surfaceFeatureExtract failed with exit code {featureResult.ExitCode}";
-
-                    _loggingService.LogError($"surfaceFeatureExtract failed with exit code {featureResult.ExitCode}");
-                    _loggingService.LogError($"surfaceFeatureExtract stdout:\n{featureResult.Output}");
-                    if (!string.IsNullOrEmpty(featureResult.Error))
-                    {
-                        _loggingService.LogError($"surfaceFeatureExtract stderr:\n{featureResult.Error}");
-                    }
-
-                    return result;
-                }
-
-                Console.WriteLine("✓ Surface features extracted successfully");
-
-                // Step 3: Run snappyHexMesh
-                if (parallel)
-                {
-                    // Decompose domain for parallel processing
-                    Console.WriteLine($"Decomposing domain for {cores} processors...");
-                    var decomposeResult = _processExecutor.Execute("decomposePar", $"-case {caseDir} -no-fields");
-
-                    if (decomposeResult.ExitCode != 0)
-                    {
-                        result.IsSuccess = false;
-                        result.ErrorMessage = $"decomposePar failed with exit code {decomposeResult.ExitCode}";
-
-                        // Log detailed error output to file
-                        _loggingService.LogError($"decomposePar failed with exit code {decomposeResult.ExitCode}");
-                        _loggingService.LogError($"decomposePar stdout:\n{decomposeResult.Output}");
-                        if (!string.IsNullOrEmpty(decomposeResult.Error))
-                        {
-                            _loggingService.LogError($"decomposePar stderr:\n{decomposeResult.Error}");
-                        }
-
-                        return result;
-                    }
-
-                    Console.WriteLine("✓ Domain decomposed successfully");
-
-                    // Copy triSurface files to each processor directory
-                    DistributeTriSurface(caseDir, cores);
-
-                    // Run snappyHexMesh in parallel
-                    Console.WriteLine($"Running snappyHexMesh in parallel ({cores} cores)...");
-                    var snappyArgs = $"-np {cores} snappyHexMesh -case {caseDir} -parallel";
-                    if (overwrite) snappyArgs += " -overwrite";
-
-                    var snappyResult = _processExecutor.Execute("mpirun", snappyArgs);
-
-                    if (snappyResult.ExitCode != 0)
-                    {
-                        result.IsSuccess = false;
-                        result.ErrorMessage = $"snappyHexMesh (parallel) failed with exit code {snappyResult.ExitCode}";
-
-                        // Log detailed error output to file
-                        _loggingService.LogError($"snappyHexMesh (parallel) failed with exit code {snappyResult.ExitCode}");
-                        _loggingService.LogError($"snappyHexMesh stdout:\n{snappyResult.Output}");
-                        if (!string.IsNullOrEmpty(snappyResult.Error))
-                        {
-                            _loggingService.LogError($"snappyHexMesh stderr:\n{snappyResult.Error}");
-                        }
-
-                        return result;
-                    }
-
-                    Console.WriteLine("✓ snappyHexMesh completed successfully");
-
-                    // Reconstruct mesh
-                    Console.WriteLine("Reconstructing mesh...");
-                    var reconstructResult = _processExecutor.Execute("reconstructParMesh", $"-case {caseDir} -constant");
-
-                    if (reconstructResult.ExitCode != 0)
-                    {
-                        result.Warnings.Add($"reconstructParMesh returned exit code {reconstructResult.ExitCode} (may be non-critical)");
+                        stepResult = _processExecutor.Execute("mpirun", $"-np {cores} {step.Command} {resolvedArgs} -parallel");
                     }
                     else
                     {
-                        Console.WriteLine("✓ Mesh reconstructed successfully");
+                        stepResult = _processExecutor.Execute(step.Command, resolvedArgs);
                     }
-                }
-                else
-                {
-                    // Run snappyHexMesh in serial
-                    Console.WriteLine("Running snappyHexMesh...");
-                    var snappyArgs = $"-case {caseDir}";
-                    if (overwrite) snappyArgs += " -overwrite";
 
-                    var snappyResult = _processExecutor.Execute("snappyHexMesh", snappyArgs);
-
-                    if (snappyResult.ExitCode != 0)
+                    if (stepResult.ExitCode != 0)
                     {
-                        result.IsSuccess = false;
-                        result.ErrorMessage = $"snappyHexMesh failed with exit code {snappyResult.ExitCode}";
-
-                        // Log detailed error output to file
-                        _loggingService.LogError($"snappyHexMesh failed with exit code {snappyResult.ExitCode}");
-                        _loggingService.LogError($"snappyHexMesh stdout:\n{snappyResult.Output}");
-                        if (!string.IsNullOrEmpty(snappyResult.Error))
+                        if (step.Optional)
                         {
-                            _loggingService.LogError($"snappyHexMesh stderr:\n{snappyResult.Error}");
+                            result.Warnings.Add($"{step.Command} failed (optional step — continuing)");
+                            _loggingService.LogError($"{step.Command} failed: {stepResult.Output}");
+                        }
+                        else if (step.Command == "checkMesh")
+                        {
+                            // checkMesh failure is non-fatal — parse output and add warning
+                            ParseCheckMeshOutput(stepResult.Output, result);
+                            result.MeshQualityPassed = false;
+                            result.Warnings.Add("Mesh quality check failed - review mesh for issues");
+                        }
+                        else if (step.Command == "reconstructParMesh")
+                        {
+                            // reconstructParMesh failure is non-critical
+                            result.Warnings.Add($"reconstructParMesh returned exit code {stepResult.ExitCode} (may be non-critical)");
+                        }
+                        else
+                        {
+                            result.IsSuccess = false;
+                            result.ErrorMessage = $"{step.Command} failed with exit code {stepResult.ExitCode}";
+                            _loggingService.LogError($"{step.Command} stdout:\n{stepResult.Output}");
+                            if (!string.IsNullOrEmpty(stepResult.Error))
+                                _loggingService.LogError($"{step.Command} stderr:\n{stepResult.Error}");
+                            return result;
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"✓ {step.Command} completed successfully");
+
+                        // After successful decomposePar, distribute triSurface files to processor dirs
+                        if (step.Command == "decomposePar")
+                        {
+                            DistributeTriSurface(caseDir, cores);
                         }
 
-                        return result;
+                        // After successful checkMesh, parse output for mesh statistics
+                        if (step.Command == "checkMesh")
+                        {
+                            ParseCheckMeshOutput(stepResult.Output, result);
+                            result.MeshQualityPassed = true;
+                        }
                     }
-
-                    Console.WriteLine("✓ snappyHexMesh completed successfully");
                 }
 
-                // Step: Convert rotor wall patches to cyclicAMI (only for AMI templates)
+                // Post-pipeline: convert rotor wall patches to cyclicAMI if needed
                 var createPatchPath = Path.Combine(caseDir, "system", "createPatchDict");
                 if (File.Exists(createPatchPath))
                 {
                     PatchBoundaryForAMI(caseDir);
-                }
-
-
-                // Step 3: Check mesh quality (optional)
-                if (checkQuality)
-                {
-                    Console.WriteLine("Checking mesh quality...");
-                    var checkMeshResult = _processExecutor.Execute("checkMesh", $"-case {caseDir}");
-
-                    // Parse checkMesh output for mesh statistics
-                    ParseCheckMeshOutput(checkMeshResult.Output, result);
-
-                    if (checkMeshResult.ExitCode == 0)
-                    {
-                        result.MeshQualityPassed = true;
-                        Console.WriteLine("✓ Mesh quality check passed");
-                    }
-                    else
-                    {
-                        result.MeshQualityPassed = false;
-                        result.Warnings.Add("Mesh quality check failed - review mesh for issues");
-                    }
                 }
 
                 result.IsSuccess = true;
@@ -244,6 +141,22 @@ namespace foamscript.Services
                 result.ErrorMessage = $"Meshing failed: {ex.Message}";
                 return result;
             }
+        }
+
+        /// <summary>
+        /// Resolves template tokens in pipeline step arguments.
+        /// </summary>
+        private static string ResolvePipelineTokens(string args, string caseDir, TemplateMetadata metadata)
+        {
+            var geometryStlPath = Path.Combine(caseDir, "constant", "triSurface", metadata.Geometry.StlName);
+            var outsidePoint = metadata.Geometry.SurfaceOrient?.OutsidePoint is { Length: 3 } pt
+                ? $"{pt[0]} {pt[1]} {pt[2]}"
+                : "0 0 0";
+
+            return args
+                .Replace("{caseDir}", caseDir)
+                .Replace("{geometryStlPath}", geometryStlPath)
+                .Replace("{outsidePoint}", outsidePoint);
         }
 
         /// <summary>

--- a/Services/ReportService.cs
+++ b/Services/ReportService.cs
@@ -355,22 +355,25 @@ namespace foamscript.Services
             writer.WriteLine($"# Max Iterations: {config.MaxIterations}");
             writer.WriteLine("#");
 
-            // Column headers
-            writer.WriteLine("AoA_deg,Cd,Cl,CmPitch,L_over_D,Converged");
+            // Dynamic column headers from Coefficients dictionary
+            var coeffKeys = ResultsService.GetCoefficientKeys(summary);
+            var headers = new List<string> { "AoA_deg" };
+            headers.AddRange(coeffKeys);
+            headers.Add("Converged");
+            writer.WriteLine(string.Join(",", headers));
 
             // Data rows
             foreach (var c in summary.Cases)
             {
-                var ld = (c.Cl.HasValue && c.Cd.HasValue && c.Cd.Value != 0)
-                    ? $"{c.Cl.Value / c.Cd.Value:F6}"
-                    : "";
-                writer.WriteLine(string.Join(",",
-                    $"{c.AngleOfAttack:F1}",
-                    c.Cd?.ToString("F6") ?? "",
-                    c.Cl?.ToString("F6") ?? "",
-                    c.CmPitch?.ToString("F6") ?? "",
-                    ld,
-                    c.Converged));
+                var values = new List<string> { $"{c.AngleOfAttack:F1}" };
+                foreach (var key in coeffKeys)
+                {
+                    var val = c.Coefficients.TryGetValue(key, out var v) && v.HasValue
+                        ? v.Value.ToString("F6") : "";
+                    values.Add(val);
+                }
+                values.Add(c.Converged.ToString());
+                writer.WriteLine(string.Join(",", values));
             }
         }
 

--- a/Services/ReportService.cs
+++ b/Services/ReportService.cs
@@ -147,12 +147,15 @@ namespace foamscript.Services
                     Converged = c.Converged
                 }).ToList(),
 
-                // SVG charts
+                // Legacy SVG charts (backward compat for existing report.html templates)
                 ClVsAoaChart = _chartGenerator.GeneratePolarChartSvg(cases, "Cl", "Lift Coefficient vs Angle of Attack", "Lift Coefficient, C\u2097"),
                 CdVsAoaChart = _chartGenerator.GeneratePolarChartSvg(cases, "Cd", "Drag Coefficient vs Angle of Attack", "Drag Coefficient, C\u2084"),
                 CmVsAoaChart = _chartGenerator.GeneratePolarChartSvg(cases, "CmPitch", "Pitching Moment vs Angle of Attack", "Pitching Moment, C\u2098"),
                 LdVsAoaChart = _chartGenerator.GeneratePolarChartSvg(cases, "L/D", "Lift-to-Drag Ratio vs Angle of Attack", "L/D"),
                 DragPolarChart = _chartGenerator.GenerateDragPolarSvg(cases),
+
+                // Dynamic chart list from Coefficients keys
+                CoefficientCharts = BuildCoefficientCharts(cases, summary),
 
                 ConvergenceCharts = residuals.Select(r => new ConvergenceChartEntry
                 {
@@ -262,6 +265,25 @@ namespace foamscript.Services
             }
 
             return residuals;
+        }
+
+        /// <summary>
+        /// Generates one chart per coefficient key discovered in the results.
+        /// This is the data-driven replacement for the hardcoded Cl/Cd/Cm/LD chart list.
+        /// </summary>
+        private List<ChartEntry> BuildCoefficientCharts(List<CaseResult> cases, ResultsSummary summary)
+        {
+            var coeffKeys = ResultsService.GetCoefficientKeys(summary);
+            var charts = new List<ChartEntry>();
+
+            foreach (var key in coeffKeys)
+            {
+                var title = $"{key} vs Angle of Attack";
+                var svg = _chartGenerator.GeneratePolarChartSvg(cases, key, title, key);
+                charts.Add(new ChartEntry { Name = key, Title = title, Chart = svg });
+            }
+
+            return charts;
         }
 
         private static List<MeshStatEntry> CollectMeshStats(string studyDir, List<CaseResult> cases)

--- a/Services/ReportService.cs
+++ b/Services/ReportService.cs
@@ -413,7 +413,7 @@ namespace foamscript.Services
                 }
                 catch { }
             }
-            return "external_disc_rotatingwall_steady"; // backward compat fallback
+            return string.Empty; // no template name available — will use global report template
         }
 
         internal static PhysicsConfig ReadPhysicsConfig(string studyDir)

--- a/Services/ResultsService.cs
+++ b/Services/ResultsService.cs
@@ -94,22 +94,34 @@ namespace foamscript.Services
             var sb = new StringBuilder();
             var studyName = Path.GetFileName(summary.StudyDir);
 
+            // Discover coefficient column names from the first case's Coefficients dictionary
+            var coeffKeys = GetCoefficientKeys(summary);
+
             sb.AppendLine($"=== Study Results: {studyName} ===");
             sb.AppendLine();
-            sb.AppendLine($"{"AoA (°)",-10} {"Cd",10} {"Cl",10} {"Cm",10} {"Cl/Cd",10} {"Status",10}");
-            sb.AppendLine($"{new string('-', 10)} {new string('-', 10)} {new string('-', 10)} {new string('-', 10)} {new string('-', 10)} {new string('-', 10)}");
+
+            // Header: AoA + dynamic coefficient columns + Status
+            sb.Append($"{"AoA (°)",-10}");
+            foreach (var key in coeffKeys)
+                sb.Append($" {key,10}");
+            sb.AppendLine($" {"Status",10}");
+
+            sb.Append($"{new string('-', 10)}");
+            foreach (var _ in coeffKeys)
+                sb.Append($" {new string('-', 10)}");
+            sb.AppendLine($" {new string('-', 10)}");
 
             foreach (var c in summary.Cases)
             {
-                var cd = c.Cd.HasValue ? $"{c.Cd.Value:F6}" : "N/A";
-                var cl = c.Cl.HasValue ? $"{c.Cl.Value:F6}" : "N/A";
-                var cm = c.CmPitch.HasValue ? $"{c.CmPitch.Value:F6}" : "N/A";
-                var clCd = (c.Cl.HasValue && c.Cd.HasValue && c.Cd.Value != 0)
-                    ? $"{c.Cl.Value / c.Cd.Value:F2}"
-                    : "N/A";
+                sb.Append($"{c.AngleOfAttack,-10:F1}");
+                foreach (var key in coeffKeys)
+                {
+                    var val = c.Coefficients.TryGetValue(key, out var v) && v.HasValue
+                        ? $"{v.Value:F6}" : "N/A";
+                    sb.Append($" {val,10}");
+                }
                 var status = c.Converged ? "OK" : "No data";
-
-                sb.AppendLine($"{c.AngleOfAttack,-10:F1} {cd,10} {cl,10} {cm,10} {clCd,10} {status,10}");
+                sb.AppendLine($" {status,10}");
             }
 
             sb.AppendLine();
@@ -119,17 +131,46 @@ namespace foamscript.Services
         internal static string FormatCsv(ResultsSummary summary)
         {
             var sb = new StringBuilder();
-            sb.AppendLine("AoA,Cd,Cl,CmPitch,Cl/Cd,Converged");
+            var coeffKeys = GetCoefficientKeys(summary);
+
+            // Header: AoA + dynamic coefficient columns + Converged
+            sb.AppendLine(string.Join(",", new[] { "AoA" }.Concat(coeffKeys).Append("Converged")));
 
             foreach (var c in summary.Cases)
             {
-                var clCd = (c.Cl.HasValue && c.Cd.HasValue && c.Cd.Value != 0)
-                    ? $"{c.Cl.Value / c.Cd.Value:F6}"
-                    : "";
-                sb.AppendLine($"{c.AngleOfAttack:F1},{c.Cd?.ToString("F6") ?? ""},{c.Cl?.ToString("F6") ?? ""},{c.CmPitch?.ToString("F6") ?? ""},{clCd},{c.Converged}");
+                var values = new List<string> { $"{c.AngleOfAttack:F1}" };
+                foreach (var key in coeffKeys)
+                {
+                    var val = c.Coefficients.TryGetValue(key, out var v) && v.HasValue
+                        ? v.Value.ToString("F6") : "";
+                    values.Add(val);
+                }
+                values.Add(c.Converged.ToString());
+                sb.AppendLine(string.Join(",", values));
             }
 
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Discovers the coefficient column names from the cases' Coefficients dictionaries.
+        /// Returns a consistent ordered list of keys across all cases.
+        /// </summary>
+        internal static List<string> GetCoefficientKeys(ResultsSummary summary)
+        {
+            var keys = new List<string>();
+            foreach (var c in summary.Cases)
+            {
+                foreach (var key in c.Coefficients.Keys)
+                {
+                    if (!keys.Contains(key))
+                        keys.Add(key);
+                }
+            }
+            // If no cases have coefficients, fall back to standard columns
+            if (keys.Count == 0)
+                keys.AddRange(new[] { "Cd", "Cl", "CmPitch" });
+            return keys;
         }
 
         internal static string FormatJson(ResultsSummary summary)

--- a/Services/SolverService.cs
+++ b/Services/SolverService.cs
@@ -5,21 +5,24 @@ namespace foamscript.Services
 {
     /// <summary>
     /// Service for running OpenFOAM solvers on meshed cases.
+    /// Uses template-driven pipeline from TEMPLATE.json solvePipeline.
     /// </summary>
     public class SolverService
     {
         private readonly IProcessExecutor _processExecutor;
         private readonly LoggingService _loggingService;
+        private readonly TemplateMetadataService _metadataService;
 
-        public SolverService(IProcessExecutor processExecutor, LoggingService loggingService)
+        public SolverService(IProcessExecutor processExecutor, LoggingService loggingService, TemplateMetadataService metadataService)
         {
             _processExecutor = processExecutor;
             _loggingService = loggingService;
+            _metadataService = metadataService;
         }
 
         /// <summary>
-        /// Runs the OpenFOAM solver on a single meshed case.
-        /// Automatically detects the solver (simpleFoam, pimpleFoam, etc.) from controlDict.
+        /// Runs the OpenFOAM solver on a single meshed case using the template-driven pipeline.
+        /// Pipeline steps come from TEMPLATE.json solvePipeline.
         /// </summary>
         public virtual SolveResult SolveCase(string caseDir, bool parallel, int cores)
         {
@@ -53,82 +56,72 @@ namespace foamscript.Services
                     return result;
                 }
 
-                // Detect solver from controlDict (simpleFoam, pimpleFoam, etc.)
-                var solverName = DetectSolver(caseDir);
-                var isTransient = solverName == "pimpleFoam";
+                // Load template metadata for pipeline definition
+                var metadata = _metadataService.LoadMetadata(caseDir);
 
                 if (parallel)
                 {
-                    // Clean old processor directories if present
+                    // Clean old processor directories before parallel execution
                     CleanProcessorDirs(caseDir);
+                }
 
-                    // Decompose — transient solvers use -force (time-varying fields)
-                    Console.WriteLine($"Decomposing case for {cores} processors...");
-                    var decomposeArgs = isTransient
-                        ? $"-case {caseDir} -force"
-                        : $"-case {caseDir}";
-                    var decomposeResult = _processExecutor.Execute("decomposePar", decomposeArgs);
+                // Execute solve pipeline from TEMPLATE.json
+                foreach (var step in metadata.SolvePipeline)
+                {
+                    // Skip parallel-only steps (decomposePar, reconstructPar) in serial mode
+                    if (step.ParallelOnly && !parallel)
+                        continue;
 
-                    if (decomposeResult.ExitCode != 0)
+                    var resolvedArgs = ResolvePipelineTokens(step.Args, caseDir, cores);
+                    Console.WriteLine($"Running {step.Command}...");
+
+                    ProcessResult stepResult;
+                    if (step.Parallel && parallel)
                     {
-                        result.IsSuccess = false;
-                        result.ErrorMessage = $"decomposePar failed with exit code {decomposeResult.ExitCode}";
-                        LogToolError("decomposePar", decomposeResult);
-                        return result;
-                    }
-
-                    Console.WriteLine("✓ Domain decomposed successfully");
-
-                    // Run solver in parallel with shell-level log capture.
-                    // mpirun doesn't reliably pipe child process stdout through .NET's
-                    // ProcessStartInfo redirection, so we use tee to write the log file
-                    // directly at the shell level.
-                    Console.WriteLine($"Running {solverName} in parallel ({cores} cores)...");
-                    var logPath = Path.Combine(caseDir, $"log.{solverName}");
-                    var bashCmd = $"set -o pipefail; mpirun -np {cores} {solverName} -case {caseDir} -parallel 2>&1 | tee {logPath}";
-                    var solverResult = _processExecutor.Execute("bash", $"-c \"{bashCmd}\"");
-
-                    if (solverResult.ExitCode != 0)
-                    {
-                        result.IsSuccess = false;
-                        result.ErrorMessage = $"{solverName} (parallel) failed with exit code {solverResult.ExitCode}";
-                        LogToolError($"{solverName} (parallel)", solverResult);
-                        return result;
-                    }
-
-                    Console.WriteLine($"✓ {solverName} completed successfully");
-
-                    // Reconstruct
-                    Console.WriteLine("Reconstructing fields...");
-                    var reconstructResult = _processExecutor.Execute("reconstructPar", $"-case {caseDir}");
-
-                    if (reconstructResult.ExitCode != 0)
-                    {
-                        result.Warnings.Add($"reconstructPar returned exit code {reconstructResult.ExitCode} (may be non-critical)");
+                        // Parallel solver runs via bash with tee for log capture.
+                        // mpirun doesn't reliably pipe child process stdout through .NET's
+                        // ProcessStartInfo redirection, so we use tee to write the log file
+                        // directly at the shell level.
+                        var logPath = Path.Combine(caseDir, $"log.{step.Command}");
+                        var bashCmd = $"set -o pipefail; mpirun -np {cores} {step.Command} -case {caseDir} -parallel 2>&1 | tee {logPath}";
+                        stepResult = _processExecutor.Execute("bash", $"-c \"{bashCmd}\"");
                     }
                     else
                     {
-                        Console.WriteLine("✓ Fields reconstructed successfully");
+                        stepResult = _processExecutor.Execute(step.Command, resolvedArgs);
+
+                        // Persist solver log for serial runs (report generation needs it)
+                        if (step.Parallel && !parallel)
+                        {
+                            PersistSolverLog(caseDir, step.Command, stepResult.Output);
+                        }
                     }
-                }
-                else
-                {
-                    // Run solver in serial
-                    Console.WriteLine($"Running {solverName}...");
-                    var solverResult = _processExecutor.Execute(solverName, $"-case {caseDir}");
 
-                    // Persist solver log for report generation
-                    PersistSolverLog(caseDir, solverName, solverResult.Output);
-
-                    if (solverResult.ExitCode != 0)
+                    if (stepResult.ExitCode != 0)
                     {
-                        result.IsSuccess = false;
-                        result.ErrorMessage = $"{solverName} failed with exit code {solverResult.ExitCode}";
-                        LogToolError(solverName, solverResult);
-                        return result;
+                        if (step.Optional)
+                        {
+                            result.Warnings.Add($"{step.Command} failed (optional step — continuing)");
+                            _loggingService.LogError($"{step.Command} failed: {stepResult.Output}");
+                        }
+                        else if (step.Command == "reconstructPar")
+                        {
+                            // reconstructPar failure is non-critical
+                            result.Warnings.Add($"reconstructPar returned exit code {stepResult.ExitCode} (may be non-critical)");
+                        }
+                        else
+                        {
+                            result.IsSuccess = false;
+                            var label = step.Parallel && parallel ? $"{step.Command} (parallel)" : step.Command;
+                            result.ErrorMessage = $"{label} failed with exit code {stepResult.ExitCode}";
+                            LogToolError(label, stepResult);
+                            return result;
+                        }
                     }
-
-                    Console.WriteLine($"✓ {solverName} completed successfully");
+                    else
+                    {
+                        Console.WriteLine($"✓ {step.Command} completed successfully");
+                    }
                 }
 
                 // Try to extract force coefficients from postProcessing
@@ -246,6 +239,16 @@ namespace foamscript.Services
         }
 
         /// <summary>
+        /// Resolves template tokens in pipeline step arguments.
+        /// </summary>
+        private static string ResolvePipelineTokens(string args, string caseDir, int cores)
+        {
+            return args
+                .Replace("{caseDir}", caseDir)
+                .Replace("{cores}", cores.ToString());
+        }
+
+        /// <summary>
         /// Parses force coefficient data from postProcessing output.
         /// Returns time-averaged values from the last entries.
         /// </summary>
@@ -345,6 +348,7 @@ namespace foamscript.Services
         /// <summary>
         /// Detects the solver application from the case's controlDict file.
         /// Falls back to "simpleFoam" if the application line cannot be parsed.
+        /// Retained as a utility — pipeline execution uses metadata.SolvePipeline instead.
         /// </summary>
         internal static string DetectSolver(string caseDir)
         {
@@ -358,7 +362,7 @@ namespace foamscript.Services
                 var trimmed = line.Trim();
                 if (trimmed.StartsWith("application"))
                 {
-                    // Parse "application     simpleFoam;" → "simpleFoam"
+                    // Parse "application     simpleFoam;" -> "simpleFoam"
                     var match = Regex.Match(trimmed, @"application\s+(\w+)\s*;");
                     if (match.Success)
                         return match.Groups[1].Value;

--- a/Services/TemplateMetadataService.cs
+++ b/Services/TemplateMetadataService.cs
@@ -16,7 +16,7 @@ namespace foamscript.Services
         /// Throws FileNotFoundException if the file is missing.
         /// Throws JsonException if the file contains invalid JSON.
         /// </summary>
-        public TemplateMetadata LoadMetadata(string templatePath)
+        public virtual TemplateMetadata LoadMetadata(string templatePath)
         {
             var jsonPath = Path.Combine(templatePath, MetadataFileName);
 

--- a/Services/TemplateMetadataService.cs
+++ b/Services/TemplateMetadataService.cs
@@ -4,8 +4,8 @@ using foamscript.Models;
 namespace foamscript.Services
 {
     /// <summary>
-    /// Loads template metadata from TEMPLATE.json files. Falls back to disc defaults
-    /// when the file is missing, ensuring backward compatibility.
+    /// Loads template metadata from TEMPLATE.json files. Throws if the file is missing
+    /// or contains invalid JSON — every template must have a valid TEMPLATE.json.
     /// </summary>
     public class TemplateMetadataService
     {
@@ -13,7 +13,8 @@ namespace foamscript.Services
 
         /// <summary>
         /// Loads metadata from the TEMPLATE.json in the given template directory.
-        /// Returns disc-compatible defaults if the file is missing or invalid.
+        /// Throws FileNotFoundException if the file is missing.
+        /// Throws JsonException if the file contains invalid JSON.
         /// </summary>
         public TemplateMetadata LoadMetadata(string templatePath)
         {
@@ -21,41 +22,14 @@ namespace foamscript.Services
 
             if (!File.Exists(jsonPath))
             {
-                return CreateDiscDefaults(templatePath);
+                throw new FileNotFoundException(
+                    $"Template metadata file not found: {jsonPath}", jsonPath);
             }
 
-            try
-            {
-                var json = File.ReadAllText(jsonPath);
-                var metadata = JsonSerializer.Deserialize<TemplateMetadata>(json);
-                return metadata ?? CreateDiscDefaults(templatePath);
-            }
-            catch (JsonException)
-            {
-                return CreateDiscDefaults(templatePath);
-            }
-        }
-
-        private static TemplateMetadata CreateDiscDefaults(string templatePath)
-        {
-            return new TemplateMetadata
-            {
-                Name = Path.GetFileName(templatePath),
-                Description = "Template (no TEMPLATE.json found — using disc defaults)",
-                Solver = "simpleFoam",
-                GeometryType = "disc",
-                GeometryStlName = "disc.stl",
-                ReferenceDimension = "diameter",
-                ReferenceAreaFormula = "circular",
-                RequiresRotorZone = true,
-                RequiredStlFiles = ["disc.stl", "tunnel.stl"],
-                Validation = new GeometryValidation
-                {
-                    MinSize = 0.18,
-                    MaxSize = 0.35,
-                    WarningMessage = "Disc diameter outside expected PDGA range (0.21-0.30m). Ensure correct --input-units."
-                }
-            };
+            var json = File.ReadAllText(jsonPath);
+            var metadata = JsonSerializer.Deserialize<TemplateMetadata>(json)
+                ?? throw new JsonException("Deserialized TEMPLATE.json was null.");
+            return metadata;
         }
 
         /// <summary>

--- a/Templates/external_airfoil_static_steady/TEMPLATE.json
+++ b/Templates/external_airfoil_static_steady/TEMPLATE.json
@@ -31,9 +31,9 @@
   "meshPipeline": [
     { "command": "blockMesh", "args": "-case {caseDir}" },
     { "command": "surfaceFeatureExtract", "args": "-case {caseDir}" },
-    { "command": "decomposePar", "args": "-case {caseDir}" },
+    { "command": "decomposePar", "args": "-case {caseDir}", "parallelOnly": true },
     { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true },
-    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant" },
+    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant", "parallelOnly": true },
     { "command": "checkMesh", "args": "-case {caseDir}" }
   ],
   "solvePipeline": [

--- a/Templates/external_airfoil_static_steady/TEMPLATE.json
+++ b/Templates/external_airfoil_static_steady/TEMPLATE.json
@@ -2,10 +2,17 @@
   "name": "external_airfoil_static_steady",
   "description": "Steady-state 2D airfoil analysis (simpleFoam + Spalart-Allmaras)",
   "solver": "simpleFoam",
-  "geometryType": "airfoil",
-  "geometryStlName": "airfoil.stl",
-  "referenceDimension": "chord",
-  "referenceAreaFormula": "rectangular",
-  "requiresRotorZone": false,
-  "requiredStlFiles": ["airfoil.stl"]
+  "geometry": {
+    "type": "airfoil",
+    "stlName": "airfoil.stl",
+    "requiredStlFiles": ["airfoil.stl"]
+  },
+  "reference": {
+    "dimension": "chord",
+    "areaFormula": "rectangular"
+  },
+  "rotation": {
+    "enabled": false,
+    "requiresRotorZone": false
+  }
 }

--- a/Templates/external_airfoil_static_steady/TEMPLATE.json
+++ b/Templates/external_airfoil_static_steady/TEMPLATE.json
@@ -5,7 +5,8 @@
   "geometry": {
     "type": "airfoil",
     "stlName": "airfoil.stl",
-    "requiredStlFiles": ["airfoil.stl"]
+    "requiredStlFiles": ["airfoil.stl"],
+    "surfaceOrient": null
   },
   "reference": {
     "dimension": "chord",
@@ -14,5 +15,39 @@
   "rotation": {
     "enabled": false,
     "requiresRotorZone": false
+  },
+  "validation": null,
+  "parameters": {
+    "velocity": { "required": true, "description": "Freestream velocity (m/s)" },
+    "angles": { "required": true, "description": "Angle(s) of attack (degrees)" },
+    "refinementMin": { "required": false, "default": 5, "description": "Minimum refinement level" },
+    "refinementMax": { "required": false, "default": 6, "description": "Maximum refinement level" }
+  },
+  "domain": {
+    "upstream": 5.0,
+    "downstream": 10.0,
+    "radial": 5.0
+  },
+  "meshPipeline": [
+    { "command": "blockMesh", "args": "-case {caseDir}" },
+    { "command": "surfaceFeatureExtract", "args": "-case {caseDir}" },
+    { "command": "decomposePar", "args": "-case {caseDir}" },
+    { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true },
+    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant" },
+    { "command": "checkMesh", "args": "-case {caseDir}" }
+  ],
+  "solvePipeline": [
+    { "command": "decomposePar", "args": "-case {caseDir} -force" },
+    { "command": "simpleFoam", "args": "-case {caseDir}", "parallel": true },
+    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime" }
+  ],
+  "results": {
+    "type": "forceCoefficients",
+    "dataFile": "postProcessing/forces/0/coefficient.dat",
+    "columns": { "Cd": 1, "Cl": 4, "CmPitch": 7 }
+  },
+  "report": {
+    "template": "report/report.html",
+    "standard": "AIAA"
   }
 }

--- a/Templates/external_airfoil_static_steady/TEMPLATE.json
+++ b/Templates/external_airfoil_static_steady/TEMPLATE.json
@@ -37,9 +37,9 @@
     { "command": "checkMesh", "args": "-case {caseDir}" }
   ],
   "solvePipeline": [
-    { "command": "decomposePar", "args": "-case {caseDir} -force" },
+    { "command": "decomposePar", "args": "-case {caseDir} -force", "parallelOnly": true },
     { "command": "simpleFoam", "args": "-case {caseDir}", "parallel": true },
-    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime" }
+    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime", "parallelOnly": true }
   ],
   "results": {
     "type": "forceCoefficients",

--- a/Templates/external_airfoil_static_steady/report/report.html
+++ b/Templates/external_airfoil_static_steady/report/report.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ study_name }} - Aerodynamic Analysis Report</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Times New Roman', 'Georgia', serif;
+    color: #333;
+    line-height: 1.6;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 40px 60px;
+    background: #fff;
+  }
+  h1 {
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 8px;
+    color: #111;
+  }
+  h2 {
+    font-size: 18px;
+    font-weight: bold;
+    margin: 30px 0 12px 0;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #ccc;
+    color: #222;
+  }
+  h3 {
+    font-size: 15px;
+    font-weight: bold;
+    margin: 20px 0 8px 0;
+    color: #333;
+  }
+  .subtitle {
+    text-align: center;
+    font-size: 13px;
+    color: #666;
+    margin-bottom: 30px;
+  }
+  .metadata {
+    text-align: center;
+    font-size: 12px;
+    color: #888;
+    margin-bottom: 40px;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 12px 0 20px 0;
+    font-size: 13px;
+  }
+  th, td {
+    border: 1px solid #ddd;
+    padding: 8px 12px;
+    text-align: left;
+  }
+  th {
+    background: #f5f5f5;
+    font-weight: bold;
+    color: #222;
+  }
+  td.numeric {
+    text-align: right;
+    font-family: 'Courier New', monospace;
+  }
+  .chart-container {
+    margin: 20px 0;
+    text-align: center;
+    overflow: visible;
+  }
+  .chart-container svg {
+    max-width: 100%;
+    height: auto;
+    overflow: visible;
+  }
+  .chart-container img {
+    max-width: 100%;
+    height: auto;
+  }
+  .chart-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+  }
+  .chart-half {
+    flex: 1;
+    min-width: 400px;
+    max-width: 600px;
+  }
+  .chart-full {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+  .status-ok { color: #2ca02c; font-weight: bold; }
+  .status-fail { color: #d62728; font-weight: bold; }
+  .footer {
+    margin-top: 40px;
+    padding-top: 12px;
+    border-top: 1px solid #ccc;
+    font-size: 11px;
+    color: #999;
+    text-align: center;
+  }
+  @media print {
+    body { padding: 20px; }
+    .chart-container svg { max-width: 90%; }
+    .chart-half { min-width: 300px; max-width: 48%; }
+  }
+</style>
+</head>
+<body>
+
+<h1>{{ study_name }}</h1>
+<div class="subtitle">Aerodynamic Analysis Report</div>
+<div class="metadata">
+  Generated: {{ generation_date }} | FoamScript {{ version }} | Template: {{ template_name }}
+</div>
+
+<!-- Section 1: Physics & Solver Configuration -->
+<h2>1. Physics &amp; Solver Configuration</h2>
+<table>
+  <tr><th>Parameter</th><th>Value</th></tr>
+  <tr><td>Freestream velocity</td><td class="numeric">{{ velocity }} m/s</td></tr>
+  <tr><td>RPM</td><td class="numeric">{{ rpm }}</td></tr>
+  <tr><td>Turbulence intensity</td><td class="numeric">{{ turbulence_intensity }}%</td></tr>
+  <tr><td>Kinematic viscosity</td><td class="numeric">{{ nu }} m&sup2;/s</td></tr>
+  <tr><td>Turbulence model</td><td>k-&omega; SST</td></tr>
+  <tr><td>Solver</td><td>{{ solver_name }} (steady-state RANS)</td></tr>
+  <tr><td>Max iterations</td><td class="numeric">{{ max_iterations }}</td></tr>
+  <tr><td>Refinement levels</td><td class="numeric">{{ refinement_min }}&ndash;{{ refinement_max }}</td></tr>
+  <tr><td>Boundary layers</td><td>8 layers, expansion ratio 1.2</td></tr>
+</table>
+
+<!-- Section 2: Mesh Summary -->
+<h2>2. Mesh Summary</h2>
+<table>
+  <tr>
+    <th>Case</th>
+    <th>AoA (&deg;)</th>
+    <th>Cells</th>
+    <th>Points</th>
+    <th>Faces</th>
+    <th>Quality</th>
+  </tr>
+  {{ for case_mesh in mesh_stats }}
+  <tr>
+    <td>{{ case_mesh.case_name }}</td>
+    <td class="numeric">{{ case_mesh.aoa }}</td>
+    <td class="numeric">{{ case_mesh.cells }}</td>
+    <td class="numeric">{{ case_mesh.points }}</td>
+    <td class="numeric">{{ case_mesh.faces }}</td>
+    <td class="{{ if case_mesh.quality_passed }}status-ok{{ else }}status-fail{{ end }}">
+      {{ if case_mesh.quality_passed }}Passed{{ else }}Failed{{ end }}
+    </td>
+  </tr>
+  {{ end }}
+</table>
+
+<!-- Section 3: Aerodynamic Coefficient Polars -->
+<h2>3. Aerodynamic Coefficient Polars</h2>
+
+<div class="chart-row">
+  <div class="chart-half">
+    <div class="chart-container">{{ cl_vs_aoa_chart }}</div>
+  </div>
+  <div class="chart-half">
+    <div class="chart-container">{{ cd_vs_aoa_chart }}</div>
+  </div>
+</div>
+
+<div class="chart-row">
+  <div class="chart-half">
+    <div class="chart-container">{{ cm_vs_aoa_chart }}</div>
+  </div>
+  <div class="chart-half">
+    <div class="chart-container">{{ ld_vs_aoa_chart }}</div>
+  </div>
+</div>
+
+<div class="chart-container">
+  {{ drag_polar_chart }}
+</div>
+
+<!-- Section 4: Coefficient Data -->
+<h2>4. Aerodynamic Coefficient Data</h2>
+<table>
+  <tr>
+    <th>AoA (&deg;)</th>
+    <th>C<sub>D</sub></th>
+    <th>C<sub>L</sub></th>
+    <th>C<sub>m,pitch</sub></th>
+    <th>L/D</th>
+    <th>Status</th>
+  </tr>
+  {{ for case_result in cases }}
+  <tr>
+    <td class="numeric">{{ case_result.aoa }}</td>
+    <td class="numeric">{{ case_result.cd }}</td>
+    <td class="numeric">{{ case_result.cl }}</td>
+    <td class="numeric">{{ case_result.cm }}</td>
+    <td class="numeric">{{ case_result.ld }}</td>
+    <td class="{{ if case_result.converged }}status-ok{{ else }}status-fail{{ end }}">
+      {{ if case_result.converged }}OK{{ else }}FAIL{{ end }}
+    </td>
+  </tr>
+  {{ end }}
+</table>
+<p style="font-size: 12px; color: #666; margin-top: 8px;">
+  Coefficients averaged over the final 10% of solver iterations. Data exported to CSV: <code>{{ study_name }}_coefficients.csv</code>
+</p>
+
+<!-- Section 5: Convergence History -->
+<h2>5. Convergence History</h2>
+{{ for convergence in convergence_charts }}
+<h3>{{ convergence.case_name }}</h3>
+<div class="chart-container">{{ convergence.chart }}</div>
+{{ end }}
+
+{{ if has_visualization }}
+<!-- Section 6: Flow Visualization -->
+<h2>6. Flow Field Visualization</h2>
+<p style="font-size: 13px; color: #555; margin-bottom: 16px;">
+  Contour plots on the y=0 symmetry plane through the disc center, extracted from the converged solution field.
+</p>
+{{ if pressure_slice_image != "" }}
+<h3>Static Pressure</h3>
+<div class="chart-container">
+  <img src="{{ pressure_slice_image }}" alt="Pressure contour on y=0 slice" style="width: 100%;">
+</div>
+{{ end }}
+{{ if velocity_slice_image != "" }}
+<h3>Velocity Magnitude</h3>
+<div class="chart-container">
+  <img src="{{ velocity_slice_image }}" alt="Velocity magnitude contour on y=0 slice" style="width: 100%;">
+</div>
+{{ end }}
+{{ end }}
+
+<div class="footer">
+  Generated by FoamScript {{ version }} &mdash; AIAA-standard aerodynamic analysis report
+</div>
+
+</body>
+</html>

--- a/Templates/external_disc_rotating-ami_transient/TEMPLATE.json
+++ b/Templates/external_disc_rotating-ami_transient/TEMPLATE.json
@@ -37,9 +37,9 @@
     { "command": "blockMesh", "args": "-case {caseDir}" },
     { "command": "surfaceOrient", "args": "{geometryStlPath} \"({outsidePoint})\" {geometryStlPath}", "optional": true },
     { "command": "surfaceFeatureExtract", "args": "-case {caseDir}" },
-    { "command": "decomposePar", "args": "-case {caseDir}" },
+    { "command": "decomposePar", "args": "-case {caseDir}", "parallelOnly": true },
     { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true },
-    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant" },
+    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant", "parallelOnly": true },
     { "command": "checkMesh", "args": "-case {caseDir}" }
   ],
   "solvePipeline": [

--- a/Templates/external_disc_rotating-ami_transient/TEMPLATE.json
+++ b/Templates/external_disc_rotating-ami_transient/TEMPLATE.json
@@ -5,7 +5,8 @@
   "geometry": {
     "type": "disc",
     "stlName": "disc.stl",
-    "requiredStlFiles": ["disc.stl", "rotor.stl", "tunnel.stl"]
+    "requiredStlFiles": ["disc.stl", "rotor.stl", "tunnel.stl"],
+    "surfaceOrient": { "outsidePoint": [0, 0, -1] }
   },
   "reference": {
     "dimension": "diameter",
@@ -19,5 +20,40 @@
     "minSize": 0.18,
     "maxSize": 0.35,
     "warningMessage": "Disc diameter outside expected PDGA range (0.21-0.30m). Ensure correct --input-units."
+  },
+  "parameters": {
+    "velocity": { "required": true, "description": "Freestream velocity (m/s)" },
+    "rpm": { "required": true, "description": "Rotational speed (RPM)" },
+    "angles": { "required": true, "description": "Angle(s) of attack (degrees)" },
+    "refinementMin": { "required": false, "default": 5, "description": "Minimum refinement level" },
+    "refinementMax": { "required": false, "default": 6, "description": "Maximum refinement level" }
+  },
+  "domain": {
+    "upstream": 5.0,
+    "downstream": 10.0,
+    "radial": 5.0
+  },
+  "meshPipeline": [
+    { "command": "blockMesh", "args": "-case {caseDir}" },
+    { "command": "surfaceOrient", "args": "{geometryStlPath} \"({outsidePoint})\" {geometryStlPath}", "optional": true },
+    { "command": "surfaceFeatureExtract", "args": "-case {caseDir}" },
+    { "command": "decomposePar", "args": "-case {caseDir}" },
+    { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true },
+    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant" },
+    { "command": "checkMesh", "args": "-case {caseDir}" }
+  ],
+  "solvePipeline": [
+    { "command": "decomposePar", "args": "-case {caseDir} -force" },
+    { "command": "pimpleFoam", "args": "-case {caseDir}", "parallel": true },
+    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime" }
+  ],
+  "results": {
+    "type": "forceCoefficients",
+    "dataFile": "postProcessing/forces/0/coefficient.dat",
+    "columns": { "Cd": 1, "Cl": 4, "CmPitch": 7 }
+  },
+  "report": {
+    "template": "report/report.html",
+    "standard": "AIAA"
   }
 }

--- a/Templates/external_disc_rotating-ami_transient/TEMPLATE.json
+++ b/Templates/external_disc_rotating-ami_transient/TEMPLATE.json
@@ -2,12 +2,19 @@
   "name": "external_disc_rotating-ami_transient",
   "description": "Transient AMI simulation of rotating disc (pimpleFoam + sliding mesh interface)",
   "solver": "pimpleFoam",
-  "geometryType": "disc",
-  "geometryStlName": "disc.stl",
-  "referenceDimension": "diameter",
-  "referenceAreaFormula": "circular",
-  "requiresRotorZone": true,
-  "requiredStlFiles": ["disc.stl", "rotor.stl", "tunnel.stl"],
+  "geometry": {
+    "type": "disc",
+    "stlName": "disc.stl",
+    "requiredStlFiles": ["disc.stl", "rotor.stl", "tunnel.stl"]
+  },
+  "reference": {
+    "dimension": "diameter",
+    "areaFormula": "circular"
+  },
+  "rotation": {
+    "enabled": true,
+    "requiresRotorZone": true
+  },
   "validation": {
     "minSize": 0.18,
     "maxSize": 0.35,

--- a/Templates/external_disc_rotating-ami_transient/TEMPLATE.json
+++ b/Templates/external_disc_rotating-ami_transient/TEMPLATE.json
@@ -43,9 +43,9 @@
     { "command": "checkMesh", "args": "-case {caseDir}" }
   ],
   "solvePipeline": [
-    { "command": "decomposePar", "args": "-case {caseDir} -force" },
+    { "command": "decomposePar", "args": "-case {caseDir} -force", "parallelOnly": true },
     { "command": "pimpleFoam", "args": "-case {caseDir}", "parallel": true },
-    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime" }
+    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime", "parallelOnly": true }
   ],
   "results": {
     "type": "forceCoefficients",

--- a/Templates/external_disc_rotating-ami_transient/report/report.html
+++ b/Templates/external_disc_rotating-ami_transient/report/report.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ study_name }} - Aerodynamic Analysis Report</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Times New Roman', 'Georgia', serif;
+    color: #333;
+    line-height: 1.6;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 40px 60px;
+    background: #fff;
+  }
+  h1 {
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 8px;
+    color: #111;
+  }
+  h2 {
+    font-size: 18px;
+    font-weight: bold;
+    margin: 30px 0 12px 0;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #ccc;
+    color: #222;
+  }
+  h3 {
+    font-size: 15px;
+    font-weight: bold;
+    margin: 20px 0 8px 0;
+    color: #333;
+  }
+  .subtitle {
+    text-align: center;
+    font-size: 13px;
+    color: #666;
+    margin-bottom: 30px;
+  }
+  .metadata {
+    text-align: center;
+    font-size: 12px;
+    color: #888;
+    margin-bottom: 40px;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 12px 0 20px 0;
+    font-size: 13px;
+  }
+  th, td {
+    border: 1px solid #ddd;
+    padding: 8px 12px;
+    text-align: left;
+  }
+  th {
+    background: #f5f5f5;
+    font-weight: bold;
+    color: #222;
+  }
+  td.numeric {
+    text-align: right;
+    font-family: 'Courier New', monospace;
+  }
+  .chart-container {
+    margin: 20px 0;
+    text-align: center;
+    overflow: visible;
+  }
+  .chart-container svg {
+    max-width: 100%;
+    height: auto;
+    overflow: visible;
+  }
+  .chart-container img {
+    max-width: 100%;
+    height: auto;
+  }
+  .chart-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+  }
+  .chart-half {
+    flex: 1;
+    min-width: 400px;
+    max-width: 600px;
+  }
+  .chart-full {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+  .status-ok { color: #2ca02c; font-weight: bold; }
+  .status-fail { color: #d62728; font-weight: bold; }
+  .footer {
+    margin-top: 40px;
+    padding-top: 12px;
+    border-top: 1px solid #ccc;
+    font-size: 11px;
+    color: #999;
+    text-align: center;
+  }
+  @media print {
+    body { padding: 20px; }
+    .chart-container svg { max-width: 90%; }
+    .chart-half { min-width: 300px; max-width: 48%; }
+  }
+</style>
+</head>
+<body>
+
+<h1>{{ study_name }}</h1>
+<div class="subtitle">Aerodynamic Analysis Report</div>
+<div class="metadata">
+  Generated: {{ generation_date }} | FoamScript {{ version }} | Template: {{ template_name }}
+</div>
+
+<!-- Section 1: Physics & Solver Configuration -->
+<h2>1. Physics &amp; Solver Configuration</h2>
+<table>
+  <tr><th>Parameter</th><th>Value</th></tr>
+  <tr><td>Freestream velocity</td><td class="numeric">{{ velocity }} m/s</td></tr>
+  <tr><td>RPM</td><td class="numeric">{{ rpm }}</td></tr>
+  <tr><td>Turbulence intensity</td><td class="numeric">{{ turbulence_intensity }}%</td></tr>
+  <tr><td>Kinematic viscosity</td><td class="numeric">{{ nu }} m&sup2;/s</td></tr>
+  <tr><td>Turbulence model</td><td>k-&omega; SST</td></tr>
+  <tr><td>Solver</td><td>{{ solver_name }} (steady-state RANS)</td></tr>
+  <tr><td>Max iterations</td><td class="numeric">{{ max_iterations }}</td></tr>
+  <tr><td>Refinement levels</td><td class="numeric">{{ refinement_min }}&ndash;{{ refinement_max }}</td></tr>
+  <tr><td>Boundary layers</td><td>8 layers, expansion ratio 1.2</td></tr>
+</table>
+
+<!-- Section 2: Mesh Summary -->
+<h2>2. Mesh Summary</h2>
+<table>
+  <tr>
+    <th>Case</th>
+    <th>AoA (&deg;)</th>
+    <th>Cells</th>
+    <th>Points</th>
+    <th>Faces</th>
+    <th>Quality</th>
+  </tr>
+  {{ for case_mesh in mesh_stats }}
+  <tr>
+    <td>{{ case_mesh.case_name }}</td>
+    <td class="numeric">{{ case_mesh.aoa }}</td>
+    <td class="numeric">{{ case_mesh.cells }}</td>
+    <td class="numeric">{{ case_mesh.points }}</td>
+    <td class="numeric">{{ case_mesh.faces }}</td>
+    <td class="{{ if case_mesh.quality_passed }}status-ok{{ else }}status-fail{{ end }}">
+      {{ if case_mesh.quality_passed }}Passed{{ else }}Failed{{ end }}
+    </td>
+  </tr>
+  {{ end }}
+</table>
+
+<!-- Section 3: Aerodynamic Coefficient Polars -->
+<h2>3. Aerodynamic Coefficient Polars</h2>
+
+<div class="chart-row">
+  <div class="chart-half">
+    <div class="chart-container">{{ cl_vs_aoa_chart }}</div>
+  </div>
+  <div class="chart-half">
+    <div class="chart-container">{{ cd_vs_aoa_chart }}</div>
+  </div>
+</div>
+
+<div class="chart-row">
+  <div class="chart-half">
+    <div class="chart-container">{{ cm_vs_aoa_chart }}</div>
+  </div>
+  <div class="chart-half">
+    <div class="chart-container">{{ ld_vs_aoa_chart }}</div>
+  </div>
+</div>
+
+<div class="chart-container">
+  {{ drag_polar_chart }}
+</div>
+
+<!-- Section 4: Coefficient Data -->
+<h2>4. Aerodynamic Coefficient Data</h2>
+<table>
+  <tr>
+    <th>AoA (&deg;)</th>
+    <th>C<sub>D</sub></th>
+    <th>C<sub>L</sub></th>
+    <th>C<sub>m,pitch</sub></th>
+    <th>L/D</th>
+    <th>Status</th>
+  </tr>
+  {{ for case_result in cases }}
+  <tr>
+    <td class="numeric">{{ case_result.aoa }}</td>
+    <td class="numeric">{{ case_result.cd }}</td>
+    <td class="numeric">{{ case_result.cl }}</td>
+    <td class="numeric">{{ case_result.cm }}</td>
+    <td class="numeric">{{ case_result.ld }}</td>
+    <td class="{{ if case_result.converged }}status-ok{{ else }}status-fail{{ end }}">
+      {{ if case_result.converged }}OK{{ else }}FAIL{{ end }}
+    </td>
+  </tr>
+  {{ end }}
+</table>
+<p style="font-size: 12px; color: #666; margin-top: 8px;">
+  Coefficients averaged over the final 10% of solver iterations. Data exported to CSV: <code>{{ study_name }}_coefficients.csv</code>
+</p>
+
+<!-- Section 5: Convergence History -->
+<h2>5. Convergence History</h2>
+{{ for convergence in convergence_charts }}
+<h3>{{ convergence.case_name }}</h3>
+<div class="chart-container">{{ convergence.chart }}</div>
+{{ end }}
+
+{{ if has_visualization }}
+<!-- Section 6: Flow Visualization -->
+<h2>6. Flow Field Visualization</h2>
+<p style="font-size: 13px; color: #555; margin-bottom: 16px;">
+  Contour plots on the y=0 symmetry plane through the disc center, extracted from the converged solution field.
+</p>
+{{ if pressure_slice_image != "" }}
+<h3>Static Pressure</h3>
+<div class="chart-container">
+  <img src="{{ pressure_slice_image }}" alt="Pressure contour on y=0 slice" style="width: 100%;">
+</div>
+{{ end }}
+{{ if velocity_slice_image != "" }}
+<h3>Velocity Magnitude</h3>
+<div class="chart-container">
+  <img src="{{ velocity_slice_image }}" alt="Velocity magnitude contour on y=0 slice" style="width: 100%;">
+</div>
+{{ end }}
+{{ end }}
+
+<div class="footer">
+  Generated by FoamScript {{ version }} &mdash; AIAA-standard aerodynamic analysis report
+</div>
+
+</body>
+</html>

--- a/Templates/external_disc_rotatingwall_steady/TEMPLATE.json
+++ b/Templates/external_disc_rotatingwall_steady/TEMPLATE.json
@@ -44,9 +44,9 @@
     { "command": "checkMesh", "args": "-case {caseDir}" }
   ],
   "solvePipeline": [
-    { "command": "decomposePar", "args": "-case {caseDir} -force" },
+    { "command": "decomposePar", "args": "-case {caseDir} -force", "parallelOnly": true },
     { "command": "simpleFoam", "args": "-case {caseDir}", "parallel": true },
-    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime" }
+    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime", "parallelOnly": true }
   ],
   "results": {
     "type": "forceCoefficients",

--- a/Templates/external_disc_rotatingwall_steady/TEMPLATE.json
+++ b/Templates/external_disc_rotatingwall_steady/TEMPLATE.json
@@ -38,9 +38,9 @@
     { "command": "blockMesh", "args": "-case {caseDir}" },
     { "command": "surfaceOrient", "args": "{geometryStlPath} \"({outsidePoint})\" {geometryStlPath}", "optional": true },
     { "command": "surfaceFeatureExtract", "args": "-case {caseDir}" },
-    { "command": "decomposePar", "args": "-case {caseDir}" },
+    { "command": "decomposePar", "args": "-case {caseDir}", "parallelOnly": true },
     { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true },
-    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant" },
+    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant", "parallelOnly": true },
     { "command": "checkMesh", "args": "-case {caseDir}" }
   ],
   "solvePipeline": [

--- a/Templates/external_disc_rotatingwall_steady/TEMPLATE.json
+++ b/Templates/external_disc_rotatingwall_steady/TEMPLATE.json
@@ -2,12 +2,19 @@
   "name": "external_disc_rotatingwall_steady",
   "description": "Steady-state MRF simulation of rotating disc (simpleFoam + rotatingWallVelocity BC)",
   "solver": "simpleFoam",
-  "geometryType": "disc",
-  "geometryStlName": "disc.stl",
-  "referenceDimension": "diameter",
-  "referenceAreaFormula": "circular",
-  "requiresRotorZone": true,
-  "requiredStlFiles": ["disc.stl", "tunnel.stl"],
+  "geometry": {
+    "type": "disc",
+    "stlName": "disc.stl",
+    "requiredStlFiles": ["disc.stl", "tunnel.stl"]
+  },
+  "reference": {
+    "dimension": "diameter",
+    "areaFormula": "circular"
+  },
+  "rotation": {
+    "enabled": true,
+    "requiresRotorZone": true
+  },
   "validation": {
     "minSize": 0.18,
     "maxSize": 0.35,

--- a/Templates/external_disc_rotatingwall_steady/TEMPLATE.json
+++ b/Templates/external_disc_rotatingwall_steady/TEMPLATE.json
@@ -5,7 +5,8 @@
   "geometry": {
     "type": "disc",
     "stlName": "disc.stl",
-    "requiredStlFiles": ["disc.stl", "tunnel.stl"]
+    "requiredStlFiles": ["disc.stl", "tunnel.stl"],
+    "surfaceOrient": { "outsidePoint": [0, 0, -1] }
   },
   "reference": {
     "dimension": "diameter",
@@ -19,5 +20,41 @@
     "minSize": 0.18,
     "maxSize": 0.35,
     "warningMessage": "Disc diameter outside expected PDGA range (0.21-0.30m). Ensure correct --input-units."
+  },
+  "parameters": {
+    "velocity": { "required": true, "description": "Freestream velocity (m/s)" },
+    "rpm": { "required": true, "description": "Rotational speed (RPM)" },
+    "angles": { "required": true, "description": "Angle(s) of attack (degrees)" },
+    "refinementMin": { "required": false, "default": 5, "description": "Minimum refinement level" },
+    "refinementMax": { "required": false, "default": 6, "description": "Maximum refinement level" },
+    "maxIterations": { "required": false, "default": 500, "description": "Maximum solver iterations" }
+  },
+  "domain": {
+    "upstream": 5.0,
+    "downstream": 10.0,
+    "radial": 5.0
+  },
+  "meshPipeline": [
+    { "command": "blockMesh", "args": "-case {caseDir}" },
+    { "command": "surfaceOrient", "args": "{geometryStlPath} \"({outsidePoint})\" {geometryStlPath}", "optional": true },
+    { "command": "surfaceFeatureExtract", "args": "-case {caseDir}" },
+    { "command": "decomposePar", "args": "-case {caseDir}" },
+    { "command": "snappyHexMesh", "args": "-case {caseDir} -overwrite", "parallel": true },
+    { "command": "reconstructParMesh", "args": "-case {caseDir} -constant" },
+    { "command": "checkMesh", "args": "-case {caseDir}" }
+  ],
+  "solvePipeline": [
+    { "command": "decomposePar", "args": "-case {caseDir} -force" },
+    { "command": "simpleFoam", "args": "-case {caseDir}", "parallel": true },
+    { "command": "reconstructPar", "args": "-case {caseDir} -latestTime" }
+  ],
+  "results": {
+    "type": "forceCoefficients",
+    "dataFile": "postProcessing/forces/0/coefficient.dat",
+    "columns": { "Cd": 1, "Cl": 4, "CmPitch": 7 }
+  },
+  "report": {
+    "template": "report/report.html",
+    "standard": "AIAA"
   }
 }

--- a/Templates/external_disc_rotatingwall_steady/report/report.html
+++ b/Templates/external_disc_rotatingwall_steady/report/report.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ study_name }} - Aerodynamic Analysis Report</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Times New Roman', 'Georgia', serif;
+    color: #333;
+    line-height: 1.6;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 40px 60px;
+    background: #fff;
+  }
+  h1 {
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 8px;
+    color: #111;
+  }
+  h2 {
+    font-size: 18px;
+    font-weight: bold;
+    margin: 30px 0 12px 0;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #ccc;
+    color: #222;
+  }
+  h3 {
+    font-size: 15px;
+    font-weight: bold;
+    margin: 20px 0 8px 0;
+    color: #333;
+  }
+  .subtitle {
+    text-align: center;
+    font-size: 13px;
+    color: #666;
+    margin-bottom: 30px;
+  }
+  .metadata {
+    text-align: center;
+    font-size: 12px;
+    color: #888;
+    margin-bottom: 40px;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 12px 0 20px 0;
+    font-size: 13px;
+  }
+  th, td {
+    border: 1px solid #ddd;
+    padding: 8px 12px;
+    text-align: left;
+  }
+  th {
+    background: #f5f5f5;
+    font-weight: bold;
+    color: #222;
+  }
+  td.numeric {
+    text-align: right;
+    font-family: 'Courier New', monospace;
+  }
+  .chart-container {
+    margin: 20px 0;
+    text-align: center;
+    overflow: visible;
+  }
+  .chart-container svg {
+    max-width: 100%;
+    height: auto;
+    overflow: visible;
+  }
+  .chart-container img {
+    max-width: 100%;
+    height: auto;
+  }
+  .chart-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+  }
+  .chart-half {
+    flex: 1;
+    min-width: 400px;
+    max-width: 600px;
+  }
+  .chart-full {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+  .status-ok { color: #2ca02c; font-weight: bold; }
+  .status-fail { color: #d62728; font-weight: bold; }
+  .footer {
+    margin-top: 40px;
+    padding-top: 12px;
+    border-top: 1px solid #ccc;
+    font-size: 11px;
+    color: #999;
+    text-align: center;
+  }
+  @media print {
+    body { padding: 20px; }
+    .chart-container svg { max-width: 90%; }
+    .chart-half { min-width: 300px; max-width: 48%; }
+  }
+</style>
+</head>
+<body>
+
+<h1>{{ study_name }}</h1>
+<div class="subtitle">Aerodynamic Analysis Report</div>
+<div class="metadata">
+  Generated: {{ generation_date }} | FoamScript {{ version }} | Template: {{ template_name }}
+</div>
+
+<!-- Section 1: Physics & Solver Configuration -->
+<h2>1. Physics &amp; Solver Configuration</h2>
+<table>
+  <tr><th>Parameter</th><th>Value</th></tr>
+  <tr><td>Freestream velocity</td><td class="numeric">{{ velocity }} m/s</td></tr>
+  <tr><td>RPM</td><td class="numeric">{{ rpm }}</td></tr>
+  <tr><td>Turbulence intensity</td><td class="numeric">{{ turbulence_intensity }}%</td></tr>
+  <tr><td>Kinematic viscosity</td><td class="numeric">{{ nu }} m&sup2;/s</td></tr>
+  <tr><td>Turbulence model</td><td>k-&omega; SST</td></tr>
+  <tr><td>Solver</td><td>{{ solver_name }} (steady-state RANS)</td></tr>
+  <tr><td>Max iterations</td><td class="numeric">{{ max_iterations }}</td></tr>
+  <tr><td>Refinement levels</td><td class="numeric">{{ refinement_min }}&ndash;{{ refinement_max }}</td></tr>
+  <tr><td>Boundary layers</td><td>8 layers, expansion ratio 1.2</td></tr>
+</table>
+
+<!-- Section 2: Mesh Summary -->
+<h2>2. Mesh Summary</h2>
+<table>
+  <tr>
+    <th>Case</th>
+    <th>AoA (&deg;)</th>
+    <th>Cells</th>
+    <th>Points</th>
+    <th>Faces</th>
+    <th>Quality</th>
+  </tr>
+  {{ for case_mesh in mesh_stats }}
+  <tr>
+    <td>{{ case_mesh.case_name }}</td>
+    <td class="numeric">{{ case_mesh.aoa }}</td>
+    <td class="numeric">{{ case_mesh.cells }}</td>
+    <td class="numeric">{{ case_mesh.points }}</td>
+    <td class="numeric">{{ case_mesh.faces }}</td>
+    <td class="{{ if case_mesh.quality_passed }}status-ok{{ else }}status-fail{{ end }}">
+      {{ if case_mesh.quality_passed }}Passed{{ else }}Failed{{ end }}
+    </td>
+  </tr>
+  {{ end }}
+</table>
+
+<!-- Section 3: Aerodynamic Coefficient Polars -->
+<h2>3. Aerodynamic Coefficient Polars</h2>
+
+<div class="chart-row">
+  <div class="chart-half">
+    <div class="chart-container">{{ cl_vs_aoa_chart }}</div>
+  </div>
+  <div class="chart-half">
+    <div class="chart-container">{{ cd_vs_aoa_chart }}</div>
+  </div>
+</div>
+
+<div class="chart-row">
+  <div class="chart-half">
+    <div class="chart-container">{{ cm_vs_aoa_chart }}</div>
+  </div>
+  <div class="chart-half">
+    <div class="chart-container">{{ ld_vs_aoa_chart }}</div>
+  </div>
+</div>
+
+<div class="chart-container">
+  {{ drag_polar_chart }}
+</div>
+
+<!-- Section 4: Coefficient Data -->
+<h2>4. Aerodynamic Coefficient Data</h2>
+<table>
+  <tr>
+    <th>AoA (&deg;)</th>
+    <th>C<sub>D</sub></th>
+    <th>C<sub>L</sub></th>
+    <th>C<sub>m,pitch</sub></th>
+    <th>L/D</th>
+    <th>Status</th>
+  </tr>
+  {{ for case_result in cases }}
+  <tr>
+    <td class="numeric">{{ case_result.aoa }}</td>
+    <td class="numeric">{{ case_result.cd }}</td>
+    <td class="numeric">{{ case_result.cl }}</td>
+    <td class="numeric">{{ case_result.cm }}</td>
+    <td class="numeric">{{ case_result.ld }}</td>
+    <td class="{{ if case_result.converged }}status-ok{{ else }}status-fail{{ end }}">
+      {{ if case_result.converged }}OK{{ else }}FAIL{{ end }}
+    </td>
+  </tr>
+  {{ end }}
+</table>
+<p style="font-size: 12px; color: #666; margin-top: 8px;">
+  Coefficients averaged over the final 10% of solver iterations. Data exported to CSV: <code>{{ study_name }}_coefficients.csv</code>
+</p>
+
+<!-- Section 5: Convergence History -->
+<h2>5. Convergence History</h2>
+{{ for convergence in convergence_charts }}
+<h3>{{ convergence.case_name }}</h3>
+<div class="chart-container">{{ convergence.chart }}</div>
+{{ end }}
+
+{{ if has_visualization }}
+<!-- Section 6: Flow Visualization -->
+<h2>6. Flow Field Visualization</h2>
+<p style="font-size: 13px; color: #555; margin-bottom: 16px;">
+  Contour plots on the y=0 symmetry plane through the disc center, extracted from the converged solution field.
+</p>
+{{ if pressure_slice_image != "" }}
+<h3>Static Pressure</h3>
+<div class="chart-container">
+  <img src="{{ pressure_slice_image }}" alt="Pressure contour on y=0 slice" style="width: 100%;">
+</div>
+{{ end }}
+{{ if velocity_slice_image != "" }}
+<h3>Velocity Magnitude</h3>
+<div class="chart-container">
+  <img src="{{ velocity_slice_image }}" alt="Velocity magnitude contour on y=0 slice" style="width: 100%;">
+</div>
+{{ end }}
+{{ end }}
+
+<div class="footer">
+  Generated by FoamScript {{ version }} &mdash; AIAA-standard aerodynamic analysis report
+</div>
+
+</body>
+</html>

--- a/foamscript.Tests/Handlers/MeshHandlerTests.cs
+++ b/foamscript.Tests/Handlers/MeshHandlerTests.cs
@@ -21,7 +21,8 @@ namespace foamscript.Tests.Handlers
             _mockMeshService = new Mock<MeshService>(
                 Mock.Of<ILogger<LoggingService>>(),
                 Mock.Of<IProcessExecutor>(),
-                _mockLoggingService.Object);
+                _mockLoggingService.Object,
+                Mock.Of<TemplateMetadataService>());
 
             _handler = new MeshHandler(_mockLoggingService.Object, _mockMeshService.Object);
         }

--- a/foamscript.Tests/Handlers/NewStudyHandlerTests.cs
+++ b/foamscript.Tests/Handlers/NewStudyHandlerTests.cs
@@ -34,7 +34,7 @@ namespace foamscript.Tests.Handlers
                 templateService,
                 metadataService);
 
-            _handler = new NewStudyHandler(_mockLoggingService.Object, _mockCaseService.Object);
+            _handler = new NewStudyHandler(_mockLoggingService.Object, _mockCaseService.Object, metadataService);
         }
 
         public void Dispose()
@@ -69,10 +69,13 @@ namespace foamscript.Tests.Handlers
 
         private static NewStudyModel CreateValidCliModel() => new NewStudyModel
         {
+            TemplatePath = "external_disc_rotatingwall_steady",
             ProjectName = "TestProject",
             OutputDir = Path.GetTempPath(),
             ModelSource = "/tmp/disc.stl",
-            Angles = "0,5,10"
+            Angles = "0,5,10",
+            Velocity = 27.0,
+            Rpm = 925.0
         };
 
         private static string CreateValidJsonConfig(string? outputDir = null)

--- a/foamscript.Tests/Handlers/SolveHandlerTests.cs
+++ b/foamscript.Tests/Handlers/SolveHandlerTests.cs
@@ -20,7 +20,8 @@ namespace foamscript.Tests.Handlers
             _mockLoggingService = new Mock<LoggingService>(Mock.Of<ILogger<LoggingService>>());
             _mockSolverService = new Mock<SolverService>(
                 Mock.Of<IProcessExecutor>(),
-                _mockLoggingService.Object);
+                _mockLoggingService.Object,
+                Mock.Of<TemplateMetadataService>());
 
             _handler = new SolveHandler(_mockLoggingService.Object, _mockSolverService.Object);
         }

--- a/foamscript.Tests/Services/CaseServiceTests.cs
+++ b/foamscript.Tests/Services/CaseServiceTests.cs
@@ -101,6 +101,28 @@ endsolid disc
             File.WriteAllText(Path.Combine(templateDir, "system", "controlDict"),
                 "endTime {{ end_time }};");
 
+            // TEMPLATE.json — required by TemplateMetadataService
+            File.WriteAllText(Path.Combine(templateDir, "TEMPLATE.json"), """
+            {
+              "name": "test_template",
+              "description": "Minimal test template",
+              "solver": "simpleFoam",
+              "geometry": {
+                "type": "disc",
+                "stlName": "disc.stl",
+                "requiredStlFiles": ["disc.stl", "tunnel.stl"]
+              },
+              "reference": {
+                "dimension": "diameter",
+                "areaFormula": "circular"
+              },
+              "rotation": {
+                "enabled": true,
+                "requiresRotorZone": true
+              }
+            }
+            """);
+
             return templateDir;
         }
 

--- a/foamscript.Tests/Services/MeshServiceTests.cs
+++ b/foamscript.Tests/Services/MeshServiceTests.cs
@@ -11,6 +11,7 @@ namespace foamscript.Tests.Services
     {
         private readonly Mock<IProcessExecutor> _mockProcessExecutor;
         private readonly Mock<LoggingService> _mockLoggingService;
+        private readonly Mock<TemplateMetadataService> _mockMetadataService;
         private readonly MeshService _service;
         private readonly List<string> _tempDirs = new();
 
@@ -18,10 +19,12 @@ namespace foamscript.Tests.Services
         {
             _mockProcessExecutor = new Mock<IProcessExecutor>();
             _mockLoggingService = new Mock<LoggingService>(Mock.Of<ILogger<LoggingService>>());
+            _mockMetadataService = new Mock<TemplateMetadataService>();
             _service = new MeshService(
                 Mock.Of<ILogger<LoggingService>>(),
                 _mockProcessExecutor.Object,
-                _mockLoggingService.Object);
+                _mockLoggingService.Object,
+                _mockMetadataService.Object);
         }
 
         public void Dispose()
@@ -43,41 +46,63 @@ namespace foamscript.Tests.Services
             return dir;
         }
 
-        private void SetupBlockMeshSuccess(string caseDir) =>
-            _mockProcessExecutor
-                .Setup(x => x.Execute("blockMesh", $"-case {caseDir}"))
-                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
-
-        private void SetupSurfaceOrientSuccess() =>
-            _mockProcessExecutor
-                .Setup(x => x.Execute("surfaceOrient", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
-
-        private void SetupFeatureExtractSuccess(string caseDir) =>
-            _mockProcessExecutor
-                .Setup(x => x.Execute("surfaceFeatureExtract", $"-case {caseDir}"))
-                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
-
-        private void SetupSerialSnappySuccess(string caseDir, bool overwrite = false)
+        /// <summary>
+        /// Returns a TemplateMetadata matching the disc rotatingwall steady template's mesh pipeline.
+        /// Serial pipeline: blockMesh → surfaceOrient (optional) → surfaceFeatureExtract → snappyHexMesh → checkMesh
+        /// Parallel pipeline: adds decomposePar (parallelOnly) before snappy and reconstructParMesh (parallelOnly) after.
+        /// </summary>
+        private static TemplateMetadata CreateDiscMetadata()
         {
-            var args = $"-case {caseDir}";
-            if (overwrite) args += " -overwrite";
+            return new TemplateMetadata
+            {
+                Name = "external_disc_rotatingwall_steady",
+                Solver = "simpleFoam",
+                Geometry = new GeometryConfig
+                {
+                    Type = "disc",
+                    StlName = "disc.stl",
+                    RequiredStlFiles = new[] { "disc.stl", "tunnel.stl" },
+                    SurfaceOrient = new SurfaceOrientConfig { OutsidePoint = new[] { 0.0, 0.0, -1.0 } }
+                },
+                MeshPipeline = new List<PipelineStep>
+                {
+                    new() { Command = "blockMesh", Args = "-case {caseDir}" },
+                    new() { Command = "surfaceOrient", Args = "{geometryStlPath} \"({outsidePoint})\" {geometryStlPath}", Optional = true },
+                    new() { Command = "surfaceFeatureExtract", Args = "-case {caseDir}" },
+                    new() { Command = "decomposePar", Args = "-case {caseDir}", ParallelOnly = true },
+                    new() { Command = "snappyHexMesh", Args = "-case {caseDir} -overwrite", Parallel = true },
+                    new() { Command = "reconstructParMesh", Args = "-case {caseDir} -constant", ParallelOnly = true },
+                    new() { Command = "checkMesh", Args = "-case {caseDir}" }
+                }
+            };
+        }
+
+        private void SetupMetadata(string caseDir, TemplateMetadata? metadata = null)
+        {
+            _mockMetadataService
+                .Setup(x => x.LoadMetadata(caseDir))
+                .Returns(metadata ?? CreateDiscMetadata());
+        }
+
+        private void SetupAllCommandsSuccess()
+        {
             _mockProcessExecutor
-                .Setup(x => x.Execute("snappyHexMesh", args))
+                .Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 0, Output = "" });
         }
 
-        private void SetupParallelWorkflowSuccess(string caseDir, int cores = 4)
+        private void SetupCommandFailure(string command, string output = "FOAM FATAL ERROR")
         {
             _mockProcessExecutor
-                .Setup(x => x.Execute("decomposePar", $"-case {caseDir} -no-fields"))
-                .Returns(new ProcessResult { ExitCode = 0 });
+                .Setup(x => x.Execute(command, It.IsAny<string>()))
+                .Returns(new ProcessResult { ExitCode = 1, Output = output });
+        }
+
+        private void SetupCommandSuccess(string command)
+        {
             _mockProcessExecutor
-                .Setup(x => x.Execute("mpirun", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("reconstructParMesh", $"-case {caseDir} -constant"))
-                .Returns(new ProcessResult { ExitCode = 0 });
+                .Setup(x => x.Execute(command, It.IsAny<string>()))
+                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
         }
 
         // ── MeshCase — Input Validation ────────────────────────────────────────────
@@ -120,13 +145,41 @@ namespace foamscript.Tests.Services
         // ── MeshCase — Serial Workflow ─────────────────────────────────────────────
 
         [Fact]
+        public void MeshCase_Serial_ExecutesPipelineStepsInOrder()
+        {
+            var caseDir = CreateValidCaseDir();
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+
+            _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
+
+            // blockMesh, surfaceOrient, surfaceFeatureExtract, snappyHexMesh all called
+            _mockProcessExecutor.Verify(x => x.Execute("blockMesh", It.IsAny<string>()), Times.Once);
+            _mockProcessExecutor.Verify(x => x.Execute("surfaceOrient", It.IsAny<string>()), Times.Once);
+            _mockProcessExecutor.Verify(x => x.Execute("surfaceFeatureExtract", It.IsAny<string>()), Times.Once);
+            _mockProcessExecutor.Verify(x => x.Execute("snappyHexMesh", It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void MeshCase_Serial_SkipsParallelOnlySteps()
+        {
+            var caseDir = CreateValidCaseDir();
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+
+            _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
+
+            // decomposePar and reconstructParMesh are parallelOnly — should NOT be called in serial mode
+            _mockProcessExecutor.Verify(x => x.Execute("decomposePar", It.IsAny<string>()), Times.Never);
+            _mockProcessExecutor.Verify(x => x.Execute("reconstructParMesh", It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
         public void MeshCase_Serial_CallsBlockMeshWithCaseArg()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
 
@@ -137,9 +190,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_Serial_WhenBlockMeshFails_ReturnsFailure()
         {
             var caseDir = CreateValidCaseDir();
-            _mockProcessExecutor
-                .Setup(x => x.Execute("blockMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 1, Output = "FOAM FATAL ERROR" });
+            SetupMetadata(caseDir);
+            SetupCommandFailure("blockMesh");
 
             var result = _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
 
@@ -148,44 +200,26 @@ namespace foamscript.Tests.Services
         }
 
         [Fact]
-        public void MeshCase_Serial_CallsSnappyHexMeshWithCaseArg()
+        public void MeshCase_Serial_CallsSnappyHexMeshDirectly()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
 
-            _mockProcessExecutor.Verify(x => x.Execute("snappyHexMesh", $"-case {caseDir}"), Times.Once);
-        }
-
-        [Fact]
-        public void MeshCase_Serial_WithOverwrite_AppendsOverwriteFlag()
-        {
-            var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir, overwrite: true);
-
-            _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: true);
-
-            _mockProcessExecutor.Verify(x => x.Execute("snappyHexMesh",
-                It.Is<string>(args => args.Contains("-overwrite"))), Times.Once);
+            // In serial mode, snappyHexMesh runs directly (not via mpirun)
+            _mockProcessExecutor.Verify(x => x.Execute("snappyHexMesh", It.IsAny<string>()), Times.Once);
+            _mockProcessExecutor.Verify(x => x.Execute("mpirun", It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
         public void MeshCase_Serial_WhenSnappyFails_ReturnsFailure()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            _mockProcessExecutor
-                .Setup(x => x.Execute("snappyHexMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 1, Output = "FOAM FATAL ERROR" });
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+            SetupCommandFailure("snappyHexMesh");
 
             var result = _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
 
@@ -197,10 +231,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_Serial_WhenAllCommandsSucceed_ReturnsSuccess()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             var result = _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
 
@@ -208,32 +240,55 @@ namespace foamscript.Tests.Services
             result.ErrorMessage.Should().BeNull();
         }
 
+        [Fact]
+        public void MeshCase_Serial_WhenSurfaceOrientFails_ContinuesAsOptional()
+        {
+            var caseDir = CreateValidCaseDir();
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+            SetupCommandFailure("surfaceOrient", "surfaceOrient error");
+
+            var result = _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Warnings.Should().Contain(w => w.Contains("surfaceOrient failed"));
+        }
+
+        [Fact]
+        public void MeshCase_Serial_ResolvesTokensInSurfaceOrientArgs()
+        {
+            var caseDir = CreateValidCaseDir();
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+
+            _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
+
+            var expectedStlPath = Path.Combine(caseDir, "constant", "triSurface", "disc.stl");
+            _mockProcessExecutor.Verify(x => x.Execute("surfaceOrient",
+                It.Is<string>(args => args.Contains(expectedStlPath) && args.Contains("0 0 -1"))), Times.Once);
+        }
+
         // ── MeshCase — Parallel Workflow ───────────────────────────────────────────
 
         [Fact]
-        public void MeshCase_Parallel_CallsDecomposeParBeforeSnappy()
+        public void MeshCase_Parallel_CallsDecomposePar()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupParallelWorkflowSuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             _service.MeshCase(caseDir, parallel: true, cores: 4, checkQuality: false, overwrite: false);
 
-            _mockProcessExecutor.Verify(x => x.Execute("decomposePar", $"-case {caseDir} -no-fields"), Times.Once);
+            _mockProcessExecutor.Verify(x => x.Execute("decomposePar", It.Is<string>(args => args.Contains($"-case {caseDir}"))), Times.Once);
         }
 
         [Fact]
         public void MeshCase_Parallel_WhenDecomposeParFails_ReturnsFailure()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            _mockProcessExecutor
-                .Setup(x => x.Execute("decomposePar", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 1, Output = "Error" });
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+            SetupCommandFailure("decomposePar", "Error");
 
             var result = _service.MeshCase(caseDir, parallel: true, cores: 4, checkQuality: false, overwrite: false);
 
@@ -245,11 +300,13 @@ namespace foamscript.Tests.Services
         public void MeshCase_Parallel_CallsMpirunWithCorrectArgs()
         {
             var caseDir = CreateValidCaseDir();
+            SetupMetadata(caseDir);
             int cores = 4;
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupParallelWorkflowSuccess(caseDir, cores);
+            SetupAllCommandsSuccess();
+            // Override: snappyHexMesh with parallel=true should call mpirun
+            _mockProcessExecutor
+                .Setup(x => x.Execute("mpirun", It.IsAny<string>()))
+                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
 
             _service.MeshCase(caseDir, parallel: true, cores: cores, checkQuality: false, overwrite: false);
 
@@ -261,75 +318,24 @@ namespace foamscript.Tests.Services
         }
 
         [Fact]
-        public void MeshCase_Parallel_WithOverwrite_AppendsOverwriteToMpirunArgs()
+        public void MeshCase_Parallel_CallsReconstructParMesh()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            _mockProcessExecutor
-                .Setup(x => x.Execute("decomposePar", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("mpirun", It.Is<string>(args => args.Contains("-overwrite"))))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("reconstructParMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
-
-            _service.MeshCase(caseDir, parallel: true, cores: 4, checkQuality: false, overwrite: true);
-
-            _mockProcessExecutor.Verify(x => x.Execute("mpirun",
-                It.Is<string>(args => args.Contains("-overwrite"))), Times.Once);
-        }
-
-        [Fact]
-        public void MeshCase_Parallel_WhenSnappyFails_ReturnsFailure()
-        {
-            var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            _mockProcessExecutor
-                .Setup(x => x.Execute("decomposePar", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("mpirun", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 1, Output = "FOAM FATAL ERROR" });
-
-            var result = _service.MeshCase(caseDir, parallel: true, cores: 4, checkQuality: false, overwrite: false);
-
-            result.IsSuccess.Should().BeFalse();
-            result.ErrorMessage.Should().Contain("snappyHexMesh (parallel) failed");
-        }
-
-        [Fact]
-        public void MeshCase_Parallel_CallsReconstructParMeshWithConstantFlag()
-        {
-            var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupParallelWorkflowSuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             _service.MeshCase(caseDir, parallel: true, cores: 4, checkQuality: false, overwrite: false);
 
-            _mockProcessExecutor.Verify(x => x.Execute("reconstructParMesh", $"-case {caseDir} -constant"), Times.Once);
+            _mockProcessExecutor.Verify(x => x.Execute("reconstructParMesh",
+                It.Is<string>(args => args.Contains($"-case {caseDir}") && args.Contains("-constant"))), Times.Once);
         }
 
         [Fact]
         public void MeshCase_Parallel_WhenReconstructFails_AddsWarningButReturnsSuccess()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            _mockProcessExecutor
-                .Setup(x => x.Execute("decomposePar", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("mpirun", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
             _mockProcessExecutor
                 .Setup(x => x.Execute("reconstructParMesh", It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 1, Output = "Warning output" });
@@ -342,13 +348,27 @@ namespace foamscript.Tests.Services
         }
 
         [Fact]
+        public void MeshCase_Parallel_WhenSnappyFails_ReturnsFailure()
+        {
+            var caseDir = CreateValidCaseDir();
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+            _mockProcessExecutor
+                .Setup(x => x.Execute("mpirun", It.IsAny<string>()))
+                .Returns(new ProcessResult { ExitCode = 1, Output = "FOAM FATAL ERROR" });
+
+            var result = _service.MeshCase(caseDir, parallel: true, cores: 4, checkQuality: false, overwrite: false);
+
+            result.IsSuccess.Should().BeFalse();
+            result.ErrorMessage.Should().Contain("snappyHexMesh failed");
+        }
+
+        [Fact]
         public void MeshCase_Parallel_WhenFullWorkflowSucceeds_ReturnsSuccess()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupParallelWorkflowSuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             var result = _service.MeshCase(caseDir, parallel: true, cores: 4, checkQuality: false, overwrite: false);
 
@@ -361,13 +381,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_WhenCheckQualityTrue_CallsCheckMesh()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
-            _mockProcessExecutor
-                .Setup(x => x.Execute("checkMesh", $"-case {caseDir}"))
-                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: true, overwrite: false);
 
@@ -378,10 +393,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_WhenCheckQualityFalse_DoesNotCallCheckMesh()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
 
@@ -392,13 +405,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_WhenCheckMeshSucceeds_SetsMeshQualityPassedTrue()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
-            _mockProcessExecutor
-                .Setup(x => x.Execute("checkMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             var result = _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: true, overwrite: false);
 
@@ -409,10 +417,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_WhenCheckMeshFails_AddsWarningAndSetsMeshQualityPassedFalse()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
             _mockProcessExecutor
                 .Setup(x => x.Execute("checkMesh", It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 1, Output = "Mesh quality issues found" });
@@ -433,10 +439,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_ParsesCheckMeshOutput_ExtractsCellCount()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
             _mockProcessExecutor
                 .Setup(x => x.Execute("checkMesh", It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 0, Output = CheckMeshOutput });
@@ -450,10 +454,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_ParsesCheckMeshOutput_ExtractsPointCount()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
             _mockProcessExecutor
                 .Setup(x => x.Execute("checkMesh", It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 0, Output = CheckMeshOutput });
@@ -467,10 +469,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_ParsesCheckMeshOutput_ExtractsFaceCount()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
             _mockProcessExecutor
                 .Setup(x => x.Execute("checkMesh", It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 0, Output = CheckMeshOutput });
@@ -484,10 +484,8 @@ namespace foamscript.Tests.Services
         public void MeshCase_WhenCheckMeshOutputHasNoStats_CountsRemainNull()
         {
             var caseDir = CreateValidCaseDir();
-            SetupBlockMeshSuccess(caseDir);
-            SetupSurfaceOrientSuccess();
-            SetupFeatureExtractSuccess(caseDir);
-            SetupSerialSnappySuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
             _mockProcessExecutor
                 .Setup(x => x.Execute("checkMesh", It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 0, Output = "Mesh OK" });
@@ -498,6 +496,62 @@ namespace foamscript.Tests.Services
             result.CellCount.Should().BeNull();
             result.PointCount.Should().BeNull();
             result.FaceCount.Should().BeNull();
+        }
+
+        // ── MeshCase — Template-Driven Pipeline ───────────────────────────────────
+
+        [Fact]
+        public void MeshCase_LoadsMetadataFromCaseDir()
+        {
+            var caseDir = CreateValidCaseDir();
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+
+            _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
+
+            _mockMetadataService.Verify(x => x.LoadMetadata(caseDir), Times.Once);
+        }
+
+        [Fact]
+        public void MeshCase_WhenMetadataLoadFails_ReturnsFailure()
+        {
+            var caseDir = CreateValidCaseDir();
+            _mockMetadataService
+                .Setup(x => x.LoadMetadata(caseDir))
+                .Throws(new FileNotFoundException("TEMPLATE.json not found"));
+
+            var result = _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
+
+            result.IsSuccess.Should().BeFalse();
+            result.ErrorMessage.Should().Contain("TEMPLATE.json not found");
+        }
+
+        [Fact]
+        public void MeshCase_WithAirfoilTemplate_SkipsSurfaceOrient()
+        {
+            var caseDir = CreateValidCaseDir();
+            var airfoilMetadata = new TemplateMetadata
+            {
+                Name = "external_airfoil_static_steady",
+                Geometry = new GeometryConfig
+                {
+                    StlName = "airfoil.stl",
+                    SurfaceOrient = null
+                },
+                MeshPipeline = new List<PipelineStep>
+                {
+                    new() { Command = "blockMesh", Args = "-case {caseDir}" },
+                    new() { Command = "surfaceFeatureExtract", Args = "-case {caseDir}" },
+                    new() { Command = "snappyHexMesh", Args = "-case {caseDir} -overwrite", Parallel = true },
+                    new() { Command = "checkMesh", Args = "-case {caseDir}" }
+                }
+            };
+            SetupMetadata(caseDir, airfoilMetadata);
+            SetupAllCommandsSuccess();
+
+            _service.MeshCase(caseDir, parallel: false, cores: 1, checkQuality: false, overwrite: false);
+
+            _mockProcessExecutor.Verify(x => x.Execute("surfaceOrient", It.IsAny<string>()), Times.Never);
         }
 
         // ── MeshStudy — Input Validation ───────────────────────────────────────────
@@ -582,20 +636,15 @@ namespace foamscript.Tests.Services
 
             foreach (var name in new[] { "case_C", "case_A", "case_B" })
             {
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "constant"));
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "system"));
+                var caseDir = Path.Combine(studyDir, name);
+                Directory.CreateDirectory(Path.Combine(caseDir, "constant"));
+                Directory.CreateDirectory(Path.Combine(caseDir, "system"));
+                _mockMetadataService
+                    .Setup(x => x.LoadMetadata(caseDir))
+                    .Returns(CreateDiscMetadata());
             }
 
-            _mockProcessExecutor
-                .Setup(x => x.Execute("blockMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            SetupSurfaceOrientSuccess();
-            _mockProcessExecutor
-                .Setup(x => x.Execute("surfaceFeatureExtract", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("snappyHexMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
+            SetupAllCommandsSuccess();
 
             var result = _service.MeshStudy(studyDir, parallel: false, cores: 1,
                 checkQuality: false, overwrite: false, continueOnError: false);
@@ -613,20 +662,15 @@ namespace foamscript.Tests.Services
 
             foreach (var name in new[] { "case_0", "case_5", "case_10" })
             {
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "constant"));
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "system"));
+                var caseDir = Path.Combine(studyDir, name);
+                Directory.CreateDirectory(Path.Combine(caseDir, "constant"));
+                Directory.CreateDirectory(Path.Combine(caseDir, "system"));
+                _mockMetadataService
+                    .Setup(x => x.LoadMetadata(caseDir))
+                    .Returns(CreateDiscMetadata());
             }
 
-            _mockProcessExecutor
-                .Setup(x => x.Execute("blockMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            SetupSurfaceOrientSuccess();
-            _mockProcessExecutor
-                .Setup(x => x.Execute("surfaceFeatureExtract", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("snappyHexMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
+            SetupAllCommandsSuccess();
 
             var result = _service.MeshStudy(studyDir, parallel: false, cores: 1,
                 checkQuality: false, overwrite: false, continueOnError: false);
@@ -643,13 +687,15 @@ namespace foamscript.Tests.Services
 
             foreach (var name in new[] { "case_0", "case_5" })
             {
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "constant"));
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "system"));
+                var caseDir = Path.Combine(studyDir, name);
+                Directory.CreateDirectory(Path.Combine(caseDir, "constant"));
+                Directory.CreateDirectory(Path.Combine(caseDir, "system"));
+                _mockMetadataService
+                    .Setup(x => x.LoadMetadata(caseDir))
+                    .Returns(CreateDiscMetadata());
             }
 
-            _mockProcessExecutor
-                .Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0 });
+            SetupAllCommandsSuccess();
 
             var result = _service.MeshStudy(studyDir, parallel: false, cores: 1,
                 checkQuality: false, overwrite: false, continueOnError: false);
@@ -667,13 +713,15 @@ namespace foamscript.Tests.Services
 
             foreach (var name in new[] { "case_0", "case_5" })
             {
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "constant"));
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "system"));
+                var caseDir = Path.Combine(studyDir, name);
+                Directory.CreateDirectory(Path.Combine(caseDir, "constant"));
+                Directory.CreateDirectory(Path.Combine(caseDir, "system"));
+                _mockMetadataService
+                    .Setup(x => x.LoadMetadata(caseDir))
+                    .Returns(CreateDiscMetadata());
             }
 
-            _mockProcessExecutor
-                .Setup(x => x.Execute("blockMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 1, Output = "FOAM FATAL ERROR" });
+            SetupCommandFailure("blockMesh");
 
             var result = _service.MeshStudy(studyDir, parallel: false, cores: 1,
                 checkQuality: false, overwrite: false, continueOnError: true);
@@ -690,13 +738,15 @@ namespace foamscript.Tests.Services
 
             foreach (var name in new[] { "case_A", "case_B", "case_C" })
             {
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "constant"));
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "system"));
+                var caseDir = Path.Combine(studyDir, name);
+                Directory.CreateDirectory(Path.Combine(caseDir, "constant"));
+                Directory.CreateDirectory(Path.Combine(caseDir, "system"));
+                _mockMetadataService
+                    .Setup(x => x.LoadMetadata(caseDir))
+                    .Returns(CreateDiscMetadata());
             }
 
-            _mockProcessExecutor
-                .Setup(x => x.Execute("blockMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 1, Output = "Error" });
+            SetupCommandFailure("blockMesh");
 
             var result = _service.MeshStudy(studyDir, parallel: false, cores: 1,
                 checkQuality: false, overwrite: false, continueOnError: false);
@@ -713,13 +763,15 @@ namespace foamscript.Tests.Services
 
             foreach (var name in new[] { "case_A", "case_B", "case_C" })
             {
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "constant"));
-                Directory.CreateDirectory(Path.Combine(studyDir, name, "system"));
+                var caseDir = Path.Combine(studyDir, name);
+                Directory.CreateDirectory(Path.Combine(caseDir, "constant"));
+                Directory.CreateDirectory(Path.Combine(caseDir, "system"));
+                _mockMetadataService
+                    .Setup(x => x.LoadMetadata(caseDir))
+                    .Returns(CreateDiscMetadata());
             }
 
-            _mockProcessExecutor
-                .Setup(x => x.Execute("blockMesh", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 1, Output = "Error" });
+            SetupCommandFailure("blockMesh");
 
             var result = _service.MeshStudy(studyDir, parallel: false, cores: 1,
                 checkQuality: false, overwrite: false, continueOnError: true);

--- a/foamscript.Tests/Services/ReportServiceTests.cs
+++ b/foamscript.Tests/Services/ReportServiceTests.cs
@@ -173,7 +173,7 @@ boundaryField
                 commentLines.Should().Contain(l => l.Contains("RPM: 925"));
 
                 var dataLines = lines.Where(l => !l.StartsWith("#")).ToList();
-                dataLines[0].Should().Be("AoA_deg,Cd,Cl,CmPitch,L_over_D,Converged");
+                dataLines[0].Should().Be("AoA_deg,Cd,Cl,CmPitch,Converged");
                 dataLines.Should().HaveCount(4); // header + 3 data rows
 
                 // Verify first data row
@@ -181,7 +181,7 @@ boundaryField
                 fields[0].Should().Be("-5.0");
                 double.Parse(fields[1]).Should().BeApproximately(0.065, 0.001);
                 double.Parse(fields[2]).Should().BeApproximately(0.189, 0.001);
-                fields[5].Should().Be("True");
+                fields[4].Should().Be("True");
             }
             finally
             {

--- a/foamscript.Tests/Services/ResultsServiceTests.cs
+++ b/foamscript.Tests/Services/ResultsServiceTests.cs
@@ -177,7 +177,7 @@ namespace foamscript.Tests.Services
 
             var csv = ResultsService.FormatCsv(summary);
 
-            csv.Should().Contain("AoA,Cd,Cl,CmPitch,Cl/Cd,Converged");
+            csv.Should().Contain("AoA,Cd,Cl,CmPitch,Converged");
             csv.Should().Contain("0.0,0.045000");
         }
 
@@ -245,6 +245,100 @@ namespace foamscript.Tests.Services
 
             cases.Should().HaveCount(1);
             Path.GetFileName(cases[0]).Should().Be("Study_0.0");
+        }
+
+        // ── Generic Coefficients Dictionary ──────────────────────────────────────
+
+        [Fact]
+        public void CaseResult_BackwardCompatAccessors_ReadWriteThroughDictionary()
+        {
+            var result = new CaseResult();
+            result.Cd = 0.055;
+            result.Cl = 0.170;
+            result.CmPitch = -0.040;
+
+            result.Coefficients["Cd"].Should().Be(0.055);
+            result.Coefficients["Cl"].Should().Be(0.170);
+            result.Coefficients["CmPitch"].Should().Be(-0.040);
+        }
+
+        [Fact]
+        public void CaseResult_GenericCoefficients_AccessibleViaBackwardCompat()
+        {
+            var result = new CaseResult();
+            result.Coefficients["Cd"] = 0.055;
+            result.Coefficients["Cl"] = 0.170;
+            result.Coefficients["CmPitch"] = -0.040;
+
+            result.Cd.Should().Be(0.055);
+            result.Cl.Should().Be(0.170);
+            result.CmPitch.Should().Be(-0.040);
+        }
+
+        [Fact]
+        public void CaseResult_CustomCoefficients_AppearInDictionaryOnly()
+        {
+            var result = new CaseResult();
+            result.Coefficients["Cp"] = 1.23;
+            result.Coefficients["Cf"] = 0.005;
+
+            result.Coefficients.Should().ContainKey("Cp");
+            result.Coefficients.Should().ContainKey("Cf");
+            result.Coefficients["Cp"].Should().Be(1.23);
+        }
+
+        [Fact]
+        public void FormatCsv_WithCustomCoefficients_IncludesAllKeys()
+        {
+            var summary = new ResultsSummary
+            {
+                IsSuccess = true,
+                Cases = new List<CaseResult>
+                {
+                    new()
+                    {
+                        CaseName = "Study_0.0",
+                        AngleOfAttack = 0.0,
+                        Converged = true,
+                        Coefficients = new Dictionary<string, double?>
+                        {
+                            ["Cd"] = 0.045,
+                            ["Cl"] = 0.170,
+                            ["Cp"] = 1.23
+                        }
+                    }
+                }
+            };
+
+            var csv = ResultsService.FormatCsv(summary);
+
+            csv.Should().Contain("AoA,Cd,Cl,Cp,Converged");
+            csv.Should().Contain("0.0,0.045000,0.170000,1.230000,True");
+        }
+
+        [Fact]
+        public void GetCoefficientKeys_EmptyCases_ReturnsFallbackKeys()
+        {
+            var summary = new ResultsSummary { Cases = new List<CaseResult>() };
+            var keys = ResultsService.GetCoefficientKeys(summary);
+
+            keys.Should().BeEquivalentTo(new[] { "Cd", "Cl", "CmPitch" });
+        }
+
+        [Fact]
+        public void GetCoefficientKeys_MergesKeysFromAllCases()
+        {
+            var summary = new ResultsSummary
+            {
+                Cases = new List<CaseResult>
+                {
+                    new() { Coefficients = new Dictionary<string, double?> { ["Cd"] = 0.05, ["Cl"] = 0.17 } },
+                    new() { Coefficients = new Dictionary<string, double?> { ["Cd"] = 0.06, ["Cl"] = 0.18, ["Cp"] = 1.0 } }
+                }
+            };
+
+            var keys = ResultsService.GetCoefficientKeys(summary);
+            keys.Should().BeEquivalentTo(new[] { "Cd", "Cl", "Cp" });
         }
     }
 }

--- a/foamscript.Tests/Services/SolverServiceTests.cs
+++ b/foamscript.Tests/Services/SolverServiceTests.cs
@@ -11,6 +11,7 @@ namespace foamscript.Tests.Services
     {
         private readonly Mock<IProcessExecutor> _mockProcessExecutor;
         private readonly Mock<LoggingService> _mockLoggingService;
+        private readonly Mock<TemplateMetadataService> _mockMetadataService;
         private readonly SolverService _service;
         private readonly List<string> _tempDirs = new();
 
@@ -18,7 +19,11 @@ namespace foamscript.Tests.Services
         {
             _mockProcessExecutor = new Mock<IProcessExecutor>();
             _mockLoggingService = new Mock<LoggingService>(Mock.Of<ILogger<LoggingService>>());
-            _service = new SolverService(_mockProcessExecutor.Object, _mockLoggingService.Object);
+            _mockMetadataService = new Mock<TemplateMetadataService>();
+            _service = new SolverService(
+                _mockProcessExecutor.Object,
+                _mockLoggingService.Object,
+                _mockMetadataService.Object);
         }
 
         public void Dispose()
@@ -57,23 +62,69 @@ namespace foamscript.Tests.Services
             return studyDir;
         }
 
-        private void SetupSerialSolverSuccess(string caseDir) =>
-            _mockProcessExecutor
-                .Setup(x => x.Execute("simpleFoam", $"-case {caseDir}"))
-                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
+        /// <summary>
+        /// Returns metadata matching the disc rotatingwall steady template's solve pipeline.
+        /// Parallel pipeline: decomposePar (parallelOnly) → simpleFoam (parallel) → reconstructPar (parallelOnly)
+        /// Serial pipeline: simpleFoam only (parallelOnly steps skipped)
+        /// </summary>
+        private static TemplateMetadata CreateDiscSolveMetadata()
+        {
+            return new TemplateMetadata
+            {
+                Name = "external_disc_rotatingwall_steady",
+                Solver = "simpleFoam",
+                Geometry = new GeometryConfig
+                {
+                    Type = "disc",
+                    StlName = "disc.stl",
+                    RequiredStlFiles = new[] { "disc.stl", "tunnel.stl" },
+                    SurfaceOrient = new SurfaceOrientConfig { OutsidePoint = new[] { 0.0, 0.0, -1.0 } }
+                },
+                SolvePipeline = new List<PipelineStep>
+                {
+                    new() { Command = "decomposePar", Args = "-case {caseDir} -force", ParallelOnly = true },
+                    new() { Command = "simpleFoam", Args = "-case {caseDir}", Parallel = true },
+                    new() { Command = "reconstructPar", Args = "-case {caseDir} -latestTime", ParallelOnly = true }
+                }
+            };
+        }
 
-        private void SetupParallelSolverSuccess(string caseDir, int cores = 4)
+        /// <summary>
+        /// Returns metadata matching the airfoil steady template's solve pipeline (same structure, no rotation).
+        /// </summary>
+        private static TemplateMetadata CreateAirfoilSolveMetadata()
+        {
+            return new TemplateMetadata
+            {
+                Name = "external_airfoil_static_steady",
+                Solver = "simpleFoam",
+                Geometry = new GeometryConfig
+                {
+                    Type = "airfoil",
+                    StlName = "airfoil.stl",
+                    RequiredStlFiles = new[] { "airfoil.stl" }
+                },
+                SolvePipeline = new List<PipelineStep>
+                {
+                    new() { Command = "decomposePar", Args = "-case {caseDir}", ParallelOnly = true },
+                    new() { Command = "simpleFoam", Args = "-case {caseDir}", Parallel = true },
+                    new() { Command = "reconstructPar", Args = "-case {caseDir} -latestTime", ParallelOnly = true }
+                }
+            };
+        }
+
+        private void SetupMetadata(string caseDir, TemplateMetadata? metadata = null)
+        {
+            _mockMetadataService
+                .Setup(x => x.LoadMetadata(caseDir))
+                .Returns(metadata ?? CreateDiscSolveMetadata());
+        }
+
+        private void SetupAllCommandsSuccess()
         {
             _mockProcessExecutor
-                .Setup(x => x.Execute("decomposePar", $"-case {caseDir}"))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            // Parallel solver runs via bash with tee for log capture
-            _mockProcessExecutor
-                .Setup(x => x.Execute("bash", It.Is<string>(a => a.Contains($"mpirun -np {cores} simpleFoam -case {caseDir} -parallel"))))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("reconstructPar", $"-case {caseDir}"))
-                .Returns(new ProcessResult { ExitCode = 0 });
+                .Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
         }
 
         // ── SolveCase — Input Validation ─────────────────────────────────────────
@@ -117,26 +168,72 @@ namespace foamscript.Tests.Services
             result.ErrorMessage.Should().Contain("initial conditions");
         }
 
+        // ── SolveCase — Template-Driven Pipeline ─────────────────────────────────
+
+        [Fact]
+        public void SolveCase_LoadsMetadataFromCaseDir()
+        {
+            var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+
+            _service.SolveCase(caseDir, false, 4);
+
+            _mockMetadataService.Verify(x => x.LoadMetadata(caseDir), Times.Once);
+        }
+
+        [Fact]
+        public void SolveCase_WhenMetadataLoadFails_ReturnsFailure()
+        {
+            var caseDir = CreateMeshedCaseDir();
+            _mockMetadataService
+                .Setup(x => x.LoadMetadata(caseDir))
+                .Throws(new FileNotFoundException("TEMPLATE.json not found"));
+
+            var result = _service.SolveCase(caseDir, false, 4);
+
+            result.IsSuccess.Should().BeFalse();
+            result.ErrorMessage.Should().Contain("TEMPLATE.json not found");
+        }
+
         // ── SolveCase — Serial Workflow ──────────────────────────────────────────
 
         [Fact]
-        public void SolveCase_Serial_CallsSimpleFoam()
+        public void SolveCase_Serial_SkipsParallelOnlySteps()
         {
             var caseDir = CreateMeshedCaseDir();
-            SetupSerialSolverSuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
+
+            _service.SolveCase(caseDir, false, 4);
+
+            // decomposePar and reconstructPar are parallelOnly — should NOT be called in serial
+            _mockProcessExecutor.Verify(x => x.Execute("decomposePar", It.IsAny<string>()), Times.Never);
+            _mockProcessExecutor.Verify(x => x.Execute("reconstructPar", It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void SolveCase_Serial_CallsSolverDirectly()
+        {
+            var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             var result = _service.SolveCase(caseDir, false, 4);
 
             result.IsSuccess.Should().BeTrue();
+            // In serial mode, solver runs directly (not via mpirun/bash)
             _mockProcessExecutor.Verify(
                 x => x.Execute("simpleFoam", $"-case {caseDir}"),
                 Times.Once);
+            _mockProcessExecutor.Verify(x => x.Execute("bash", It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
         public void SolveCase_Serial_Failure_ReturnsError()
         {
             var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir);
             _mockProcessExecutor
                 .Setup(x => x.Execute("simpleFoam", $"-case {caseDir}"))
                 .Returns(new ProcessResult { ExitCode = 1, Output = "FOAM FATAL ERROR" });
@@ -147,31 +244,52 @@ namespace foamscript.Tests.Services
             result.ErrorMessage.Should().Contain("simpleFoam failed");
         }
 
+        [Fact]
+        public void SolveCase_Serial_PersistsSolverLog()
+        {
+            var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir);
+            _mockProcessExecutor
+                .Setup(x => x.Execute("simpleFoam", $"-case {caseDir}"))
+                .Returns(new ProcessResult { ExitCode = 0, Output = "solver output here" });
+
+            _service.SolveCase(caseDir, false, 4);
+
+            var logPath = Path.Combine(caseDir, "log.simpleFoam");
+            File.Exists(logPath).Should().BeTrue();
+            File.ReadAllText(logPath).Should().Contain("solver output here");
+        }
+
         // ── SolveCase — Parallel Workflow ────────────────────────────────────────
 
         [Fact]
-        public void SolveCase_Parallel_CallsDecomposeMpirunReconstruct()
+        public void SolveCase_Parallel_ExecutesFullPipeline()
         {
             var caseDir = CreateMeshedCaseDir();
-            SetupParallelSolverSuccess(caseDir);
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
 
             var result = _service.SolveCase(caseDir, true, 4);
 
             result.IsSuccess.Should().BeTrue();
+            // decomposePar and reconstructPar should be called
             _mockProcessExecutor.Verify(
-                x => x.Execute("decomposePar", $"-case {caseDir}"), Times.Once);
+                x => x.Execute("decomposePar", It.Is<string>(a => a.Contains($"-case {caseDir}"))), Times.Once);
+            // solver should be called via bash/mpirun
             _mockProcessExecutor.Verify(
-                x => x.Execute("bash", It.Is<string>(a => a.Contains($"mpirun -np 4 simpleFoam -case {caseDir} -parallel"))), Times.Once);
+                x => x.Execute("bash", It.Is<string>(a =>
+                    a.Contains($"mpirun -np 4 simpleFoam -case {caseDir} -parallel"))), Times.Once);
             _mockProcessExecutor.Verify(
-                x => x.Execute("reconstructPar", $"-case {caseDir}"), Times.Once);
+                x => x.Execute("reconstructPar", It.Is<string>(a => a.Contains($"-case {caseDir}"))), Times.Once);
         }
 
         [Fact]
         public void SolveCase_Parallel_DecomposeFailure_ReturnsError()
         {
             var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir);
             _mockProcessExecutor
-                .Setup(x => x.Execute("decomposePar", $"-case {caseDir}"))
+                .Setup(x => x.Execute("decomposePar", It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 1 });
 
             var result = _service.SolveCase(caseDir, true, 4);
@@ -184,8 +302,9 @@ namespace foamscript.Tests.Services
         public void SolveCase_Parallel_SolverFailure_ReturnsError()
         {
             var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir);
             _mockProcessExecutor
-                .Setup(x => x.Execute("decomposePar", $"-case {caseDir}"))
+                .Setup(x => x.Execute("decomposePar", It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 0 });
             _mockProcessExecutor
                 .Setup(x => x.Execute("bash", It.Is<string>(a => a.Contains($"mpirun -np 4 simpleFoam -case {caseDir} -parallel"))))
@@ -201,14 +320,10 @@ namespace foamscript.Tests.Services
         public void SolveCase_Parallel_ReconstructFailure_AddsWarning()
         {
             var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir);
+            SetupAllCommandsSuccess();
             _mockProcessExecutor
-                .Setup(x => x.Execute("decomposePar", $"-case {caseDir}"))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("bash", It.Is<string>(a => a.Contains($"mpirun -np 4 simpleFoam -case {caseDir} -parallel"))))
-                .Returns(new ProcessResult { ExitCode = 0 });
-            _mockProcessExecutor
-                .Setup(x => x.Execute("reconstructPar", $"-case {caseDir}"))
+                .Setup(x => x.Execute("reconstructPar", It.IsAny<string>()))
                 .Returns(new ProcessResult { ExitCode = 1 });
 
             var result = _service.SolveCase(caseDir, true, 4);
@@ -221,17 +336,45 @@ namespace foamscript.Tests.Services
         public void SolveCase_Parallel_CleansOldProcessorDirs()
         {
             var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir);
             // Create old processor dirs
             Directory.CreateDirectory(Path.Combine(caseDir, "processor0"));
             Directory.CreateDirectory(Path.Combine(caseDir, "processor1"));
 
-            SetupParallelSolverSuccess(caseDir);
+            SetupAllCommandsSuccess();
 
             _service.SolveCase(caseDir, true, 4);
 
             // Old processor dirs should be cleaned
             Directory.Exists(Path.Combine(caseDir, "processor0")).Should().BeFalse();
             Directory.Exists(Path.Combine(caseDir, "processor1")).Should().BeFalse();
+        }
+
+        [Fact]
+        public void SolveCase_Parallel_DecomposeUsesForceFlag()
+        {
+            var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir); // disc metadata has "-force" in decomposePar args
+            SetupAllCommandsSuccess();
+
+            _service.SolveCase(caseDir, true, 4);
+
+            _mockProcessExecutor.Verify(
+                x => x.Execute("decomposePar", It.Is<string>(a => a.Contains("-force"))), Times.Once);
+        }
+
+        [Fact]
+        public void SolveCase_Parallel_AirfoilDecomposeNoForceFlag()
+        {
+            var caseDir = CreateMeshedCaseDir();
+            SetupMetadata(caseDir, CreateAirfoilSolveMetadata());
+            SetupAllCommandsSuccess();
+
+            _service.SolveCase(caseDir, true, 4);
+
+            // Airfoil decomposePar args don't include -force
+            _mockProcessExecutor.Verify(
+                x => x.Execute("decomposePar", It.Is<string>(a => !a.Contains("-force"))), Times.Once);
         }
 
         // ── SolveStudy ──────────────────────────────────────────────────────────
@@ -263,10 +406,13 @@ namespace foamscript.Tests.Services
         {
             var studyDir = CreateStudyDir("Study_0.0", "Study_5.0");
 
-            // Setup serial solver success for both cases
-            _mockProcessExecutor
-                .Setup(x => x.Execute("simpleFoam", It.IsAny<string>()))
-                .Returns(new ProcessResult { ExitCode = 0, Output = "" });
+            // Setup metadata for both case dirs
+            foreach (var name in new[] { "Study_0.0", "Study_5.0" })
+            {
+                var caseDir = Path.Combine(studyDir, name);
+                SetupMetadata(caseDir);
+            }
+            SetupAllCommandsSuccess();
 
             var result = _service.SolveStudy(studyDir, false, 4, false);
 
@@ -283,10 +429,14 @@ namespace foamscript.Tests.Services
             var case0 = Path.Combine(studyDir, "Study_0.0");
             var case5 = Path.Combine(studyDir, "Study_5.0");
 
-            // First case fails, second succeeds
+            SetupMetadata(case0);
+            SetupMetadata(case5);
+
+            // First case: solver fails
             _mockProcessExecutor
                 .Setup(x => x.Execute("simpleFoam", $"-case {case0}"))
                 .Returns(new ProcessResult { ExitCode = 1 });
+            // Second case: solver succeeds
             _mockProcessExecutor
                 .Setup(x => x.Execute("simpleFoam", $"-case {case5}"))
                 .Returns(new ProcessResult { ExitCode = 0 });
@@ -303,6 +453,8 @@ namespace foamscript.Tests.Services
         {
             var studyDir = CreateStudyDir("Study_0.0", "Study_5.0");
             var case0 = Path.Combine(studyDir, "Study_0.0");
+
+            SetupMetadata(case0);
 
             _mockProcessExecutor
                 .Setup(x => x.Execute("simpleFoam", $"-case {case0}"))
@@ -350,15 +502,9 @@ namespace foamscript.Tests.Services
 
         // ── ParseForceCoeffsFile ─────────────────────────────────────────────────
 
-        // ── Real v2512 format — the primary test fixture must match actual OpenFOAM output ──
-
         [Fact]
         public void ParseForceCoeffsFile_V2512Format_ReturnsCorrectColumns()
         {
-            // Real OpenFOAM v2512 coefficient.dat format — 13 data columns.
-            // This test exists because a production bug read Cd(r) as Cl and Cl(f) as CmPitch
-            // due to assuming legacy 7-column format. The header-based parser must select the
-            // correct Cd, Cl, and CmPitch columns from the full v2512 layout.
             var file = Path.Combine(Path.GetTempPath(), $"coeffs-{Guid.NewGuid()}.dat");
             var content = @"# Time        Cd            Cd(f)         Cd(r)         Cl            Cl(f)         Cl(r)         CmPitch       CmRoll        CmYaw         Cs            Cs(f)         Cs(r)
 100	0.055000	0.027000	0.028000	0.170000	0.060000	0.110000	-0.040000	0.001000	0.000500	0.002000	0.001000	0.001000
@@ -378,11 +524,8 @@ namespace foamscript.Tests.Services
                 var result = SolverService.ParseForceCoeffsFile(file, 0.1);
 
                 result.Should().NotBeNull();
-                // Cd must be column "Cd" (0.0551), NOT Cd(f) or Cd(r)
                 result!.Value.Cd.Should().BeApproximately(0.0551, 0.0005);
-                // Cl must be column "Cl" (0.1705), NOT Cl(f)=0.060 or Cd(r)=0.028
                 result.Value.Cl.Should().BeApproximately(0.1705, 0.001);
-                // CmPitch must be column "CmPitch" (-0.04025), NOT Cl(f)=0.060
                 result.Value.CmPitch.Should().BeApproximately(-0.04025, 0.001);
                 result.Value.LastTime.Should().BeApproximately(1000, 1);
             }
@@ -395,11 +538,6 @@ namespace foamscript.Tests.Services
         [Fact]
         public void ParseForceCoeffsFile_V2512Format_DoesNotConfuseSubColumns()
         {
-            // Regression test: Cd(f), Cd(r), Cl(f), Cl(r) sub-columns must NOT be
-            // confused with the aggregate Cd and Cl columns. The bug was that without
-            // header parsing, parts[3] was read as Cl (actually Cd(r)) and parts[5]
-            // was read as CmPitch (actually Cl(f)). This test uses values where
-            // sub-columns differ dramatically from aggregates to catch such confusion.
             var file = Path.Combine(Path.GetTempPath(), $"coeffs-{Guid.NewGuid()}.dat");
             var content = @"# Time        Cd            Cd(f)         Cd(r)         Cl            Cl(f)         Cl(r)         CmPitch       CmRoll        CmYaw         Cs            Cs(f)         Cs(r)
 1000	0.055	0.999	0.888	0.171	0.777	0.666	-0.042	0.555	0.444	0.333	0.222	0.111";
@@ -423,8 +561,6 @@ namespace foamscript.Tests.Services
         [Fact]
         public void ParseForceCoeffsFile_LegacyFormat_StillWorks()
         {
-            // Legacy OpenFOAM format (pre-v2512) with 7 columns. The dynamic header
-            // parser must handle both old and new formats gracefully.
             var file = Path.Combine(Path.GetTempPath(), $"coeffs-{Guid.NewGuid()}.dat");
             var content = @"# Time Cd Cs Cl CmRoll CmPitch CmYaw
 0.0500	0.050	0.001	0.150	0.0001	0.015	0.0001
@@ -485,7 +621,6 @@ namespace foamscript.Tests.Services
         [Fact]
         public void ParseForceCoeffs_WithCoefficientFile_ReturnsValues()
         {
-            // Integration test using real v2512 format — verifies full path resolution + parsing
             var caseDir = CreateMeshedCaseDir();
             var postDir = Path.Combine(caseDir, "postProcessing", "forces", "0");
             Directory.CreateDirectory(postDir);

--- a/foamscript.Tests/Services/TemplateMetadataServiceTests.cs
+++ b/foamscript.Tests/Services/TemplateMetadataServiceTests.cs
@@ -221,7 +221,7 @@ namespace foamscript.Tests.Services
                 "type": "disc",
                 "stlName": "disc.stl",
                 "requiredStlFiles": ["disc.stl", "tunnel.stl"],
-                "surfaceOrient": "outward"
+                "surfaceOrient": { "outsidePoint": [0, 0, -1] }
               },
               "reference": {
                 "dimension": "diameter",
@@ -278,7 +278,8 @@ namespace foamscript.Tests.Services
             metadata.Geometry.Type.Should().Be("disc");
             metadata.Geometry.StlName.Should().Be("disc.stl");
             metadata.Geometry.RequiredStlFiles.Should().BeEquivalentTo("disc.stl", "tunnel.stl");
-            metadata.Geometry.SurfaceOrient.Should().Be("outward");
+            metadata.Geometry.SurfaceOrient.Should().NotBeNull();
+            metadata.Geometry.SurfaceOrient!.OutsidePoint.Should().BeEquivalentTo(new[] { 0.0, 0.0, -1.0 });
 
             // Reference
             metadata.Reference.Dimension.Should().Be("diameter");

--- a/foamscript.Tests/Services/TemplateMetadataServiceTests.cs
+++ b/foamscript.Tests/Services/TemplateMetadataServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Xunit;
 using FluentAssertions;
 using foamscript.Services;
@@ -35,12 +36,19 @@ namespace foamscript.Tests.Services
             {
               "name": "external_airfoil_static_steady",
               "solver": "simpleFoam",
-              "geometryType": "airfoil",
-              "geometryStlName": "airfoil.stl",
-              "referenceDimension": "chord",
-              "referenceAreaFormula": "rectangular",
-              "requiresRotorZone": false,
-              "requiredStlFiles": ["airfoil.stl", "tunnel.stl"]
+              "geometry": {
+                "type": "airfoil",
+                "stlName": "airfoil.stl",
+                "requiredStlFiles": ["airfoil.stl", "tunnel.stl"]
+              },
+              "reference": {
+                "dimension": "chord",
+                "areaFormula": "rectangular"
+              },
+              "rotation": {
+                "enabled": false,
+                "requiresRotorZone": false
+              }
             }
             """);
 
@@ -57,33 +65,25 @@ namespace foamscript.Tests.Services
         }
 
         [Fact]
-        public void LoadMetadata_MissingFile_ReturnsDiscDefaults()
+        public void LoadMetadata_MissingFile_ThrowsFileNotFoundException()
         {
             var dir = CreateTempDir();
 
-            var metadata = _service.LoadMetadata(dir);
+            var act = () => _service.LoadMetadata(dir);
 
-            metadata.GeometryType.Should().Be("disc");
-            metadata.GeometryStlName.Should().Be("disc.stl");
-            metadata.ReferenceDimension.Should().Be("diameter");
-            metadata.ReferenceAreaFormula.Should().Be("circular");
-            metadata.RequiresRotorZone.Should().BeTrue();
-            metadata.RequiredStlFiles.Should().BeEquivalentTo("disc.stl", "tunnel.stl");
-            metadata.Validation.Should().NotBeNull();
-            metadata.Validation!.MinSize.Should().Be(0.18);
-            metadata.Validation!.MaxSize.Should().Be(0.35);
+            act.Should().Throw<FileNotFoundException>()
+                .WithMessage("*TEMPLATE.json*");
         }
 
         [Fact]
-        public void LoadMetadata_InvalidJson_ReturnsDiscDefaults()
+        public void LoadMetadata_InvalidJson_ThrowsJsonException()
         {
             var dir = CreateTempDir();
             File.WriteAllText(Path.Combine(dir, "TEMPLATE.json"), "not valid json {{{");
 
-            var metadata = _service.LoadMetadata(dir);
+            var act = () => _service.LoadMetadata(dir);
 
-            metadata.GeometryType.Should().Be("disc");
-            metadata.RequiresRotorZone.Should().BeTrue();
+            act.Should().Throw<JsonException>();
         }
 
         [Fact]
@@ -93,6 +93,9 @@ namespace foamscript.Tests.Services
             File.WriteAllText(Path.Combine(dir, "TEMPLATE.json"), """
             {
               "name": "test",
+              "geometry": { "type": "disc", "stlName": "disc.stl", "requiredStlFiles": ["disc.stl"] },
+              "reference": { "dimension": "diameter", "areaFormula": "circular" },
+              "rotation": { "enabled": true, "requiresRotorZone": true },
               "validation": {
                 "minSize": 0.18,
                 "maxSize": 0.35,
@@ -116,7 +119,9 @@ namespace foamscript.Tests.Services
             File.WriteAllText(Path.Combine(dir, "TEMPLATE.json"), """
             {
               "name": "external_airfoil_static_steady",
-              "requiresRotorZone": false
+              "geometry": { "type": "airfoil", "stlName": "airfoil.stl", "requiredStlFiles": ["airfoil.stl"] },
+              "reference": { "dimension": "chord", "areaFormula": "rectangular" },
+              "rotation": { "enabled": false, "requiresRotorZone": false }
             }
             """);
 
@@ -129,7 +134,10 @@ namespace foamscript.Tests.Services
         public void CalculateReferenceDimension_Diameter_ReturnsMaxWidthOrDepth()
         {
             var bbox = new BoundingBox { MinX = -0.13, MaxX = 0.13, MinY = -0.01, MaxY = 0.01, MinZ = -0.13, MaxZ = 0.13 };
-            var metadata = new TemplateMetadata { ReferenceDimension = "diameter" };
+            var metadata = new TemplateMetadata
+            {
+                Reference = new ReferenceConfig { Dimension = "diameter", AreaFormula = "circular" }
+            };
 
             var result = TemplateMetadataService.CalculateReferenceDimension(bbox, metadata);
 
@@ -140,7 +148,10 @@ namespace foamscript.Tests.Services
         public void CalculateReferenceDimension_Chord_ReturnsWidth()
         {
             var bbox = new BoundingBox { MinX = 0, MaxX = 1.0, MinY = -0.06, MaxY = 0.06, MinZ = 0, MaxZ = 0.5 };
-            var metadata = new TemplateMetadata { ReferenceDimension = "chord" };
+            var metadata = new TemplateMetadata
+            {
+                Reference = new ReferenceConfig { Dimension = "chord", AreaFormula = "rectangular" }
+            };
 
             var result = TemplateMetadataService.CalculateReferenceDimension(bbox, metadata);
 
@@ -151,7 +162,10 @@ namespace foamscript.Tests.Services
         public void CalculateReferenceArea_Circular_ReturnsPiR2()
         {
             var bbox = new BoundingBox { MinX = -0.13, MaxX = 0.13, MinY = -0.01, MaxY = 0.01, MinZ = -0.13, MaxZ = 0.13 };
-            var metadata = new TemplateMetadata { ReferenceAreaFormula = "circular" };
+            var metadata = new TemplateMetadata
+            {
+                Reference = new ReferenceConfig { Dimension = "diameter", AreaFormula = "circular" }
+            };
             double refLength = 0.26;
 
             var result = TemplateMetadataService.CalculateReferenceArea(refLength, bbox, metadata);
@@ -163,10 +177,12 @@ namespace foamscript.Tests.Services
         [Fact]
         public void CalculateReferenceArea_Rectangular_ReturnsChordTimesSpan()
         {
-            // Airfoil: X=chord(1.0), Y=span(1.0), Z=thickness(0.12)
             var bbox = new BoundingBox { MinX = 0, MaxX = 1.0, MinY = -0.5, MaxY = 0.5, MinZ = -0.06, MaxZ = 0.06 };
-            var metadata = new TemplateMetadata { ReferenceAreaFormula = "rectangular" };
-            double refLength = 1.0; // chord
+            var metadata = new TemplateMetadata
+            {
+                Reference = new ReferenceConfig { Dimension = "chord", AreaFormula = "rectangular" }
+            };
+            double refLength = 1.0;
 
             var result = TemplateMetadataService.CalculateReferenceArea(refLength, bbox, metadata);
 
@@ -190,6 +206,159 @@ namespace foamscript.Tests.Services
             metadata.Solver.Should().Be("simpleFoam");
             metadata.GeometryType.Should().Be("disc");
             metadata.RequiresRotorZone.Should().BeTrue();
+        }
+
+        [Fact]
+        public void LoadMetadata_ExpandedSchema_ParsesAllSections()
+        {
+            var dir = CreateTempDir();
+            File.WriteAllText(Path.Combine(dir, "TEMPLATE.json"), """
+            {
+              "name": "full_template",
+              "description": "A fully specified template",
+              "solver": "simpleFoam",
+              "geometry": {
+                "type": "disc",
+                "stlName": "disc.stl",
+                "requiredStlFiles": ["disc.stl", "tunnel.stl"],
+                "surfaceOrient": "outward"
+              },
+              "reference": {
+                "dimension": "diameter",
+                "areaFormula": "circular"
+              },
+              "rotation": {
+                "enabled": true,
+                "requiresRotorZone": true
+              },
+              "parameters": {
+                "velocity": { "required": true, "default": 27.0, "description": "Freestream velocity (m/s)" },
+                "rpm": { "required": false, "default": 925, "description": "Rotational speed" }
+              },
+              "domain": {
+                "upstream": 10.0,
+                "downstream": 20.0,
+                "radial": 8.0
+              },
+              "meshPipeline": [
+                { "command": "surfaceFeatureExtract", "args": "", "parallel": false, "optional": false },
+                { "command": "blockMesh", "args": "", "parallel": false, "optional": false },
+                { "command": "snappyHexMesh", "args": "-overwrite", "parallel": true, "optional": false }
+              ],
+              "solvePipeline": [
+                { "command": "potentialFoam", "args": "-writePhi", "parallel": true, "optional": true },
+                { "command": "simpleFoam", "args": "", "parallel": true, "optional": false }
+              ],
+              "results": {
+                "type": "forceCoefficients",
+                "dataFile": "postProcessing/forceCoeffs/0/coefficient.dat",
+                "columns": { "Cd": 1, "Cl": 2, "CmPitch": 3 }
+              },
+              "report": {
+                "template": "report.html",
+                "standard": "AIAA",
+                "postProcess": ["extract_slice", "render_slice"]
+              },
+              "validation": {
+                "minSize": 0.18,
+                "maxSize": 0.35,
+                "warningMessage": "Outside range."
+              }
+            }
+            """);
+
+            var metadata = _service.LoadMetadata(dir);
+
+            // Top-level
+            metadata.Name.Should().Be("full_template");
+            metadata.Description.Should().Be("A fully specified template");
+            metadata.Solver.Should().Be("simpleFoam");
+
+            // Geometry
+            metadata.Geometry.Type.Should().Be("disc");
+            metadata.Geometry.StlName.Should().Be("disc.stl");
+            metadata.Geometry.RequiredStlFiles.Should().BeEquivalentTo("disc.stl", "tunnel.stl");
+            metadata.Geometry.SurfaceOrient.Should().Be("outward");
+
+            // Reference
+            metadata.Reference.Dimension.Should().Be("diameter");
+            metadata.Reference.AreaFormula.Should().Be("circular");
+
+            // Rotation
+            metadata.Rotation.Enabled.Should().BeTrue();
+            metadata.Rotation.RequiresRotorZone.Should().BeTrue();
+
+            // Parameters
+            metadata.Parameters.Should().ContainKey("velocity");
+            metadata.Parameters["velocity"].Required.Should().BeTrue();
+            metadata.Parameters["velocity"].Description.Should().Be("Freestream velocity (m/s)");
+            metadata.Parameters.Should().ContainKey("rpm");
+            metadata.Parameters["rpm"].Required.Should().BeFalse();
+
+            // Domain
+            metadata.Domain.Upstream.Should().Be(10.0);
+            metadata.Domain.Downstream.Should().Be(20.0);
+            metadata.Domain.Radial.Should().Be(8.0);
+
+            // MeshPipeline
+            metadata.MeshPipeline.Should().HaveCount(3);
+            metadata.MeshPipeline[0].Command.Should().Be("surfaceFeatureExtract");
+            metadata.MeshPipeline[2].Command.Should().Be("snappyHexMesh");
+            metadata.MeshPipeline[2].Parallel.Should().BeTrue();
+            metadata.MeshPipeline[2].Args.Should().Be("-overwrite");
+
+            // SolvePipeline
+            metadata.SolvePipeline.Should().HaveCount(2);
+            metadata.SolvePipeline[0].Command.Should().Be("potentialFoam");
+            metadata.SolvePipeline[0].Optional.Should().BeTrue();
+            metadata.SolvePipeline[1].Command.Should().Be("simpleFoam");
+
+            // Results
+            metadata.Results.Type.Should().Be("forceCoefficients");
+            metadata.Results.DataFile.Should().Be("postProcessing/forceCoeffs/0/coefficient.dat");
+            metadata.Results.Columns.Should().ContainKey("Cd").WhoseValue.Should().Be(1);
+            metadata.Results.Columns.Should().ContainKey("Cl").WhoseValue.Should().Be(2);
+            metadata.Results.Columns.Should().ContainKey("CmPitch").WhoseValue.Should().Be(3);
+
+            // Report
+            metadata.Report.Template.Should().Be("report.html");
+            metadata.Report.Standard.Should().Be("AIAA");
+            metadata.Report.PostProcess.Should().BeEquivalentTo("extract_slice", "render_slice");
+
+            // Validation
+            metadata.Validation.Should().NotBeNull();
+            metadata.Validation!.MinSize.Should().Be(0.18);
+            metadata.Validation!.MaxSize.Should().Be(0.35);
+
+            // Backward-compat accessors
+            metadata.GeometryType.Should().Be("disc");
+            metadata.GeometryStlName.Should().Be("disc.stl");
+            metadata.ReferenceDimension.Should().Be("diameter");
+            metadata.ReferenceAreaFormula.Should().Be("circular");
+            metadata.RequiresRotorZone.Should().BeTrue();
+            metadata.RequiredStlFiles.Should().BeEquivalentTo("disc.stl", "tunnel.stl");
+        }
+
+        [Fact]
+        public void LoadMetadata_NullSurfaceOrient_ParsesAsNull()
+        {
+            var dir = CreateTempDir();
+            File.WriteAllText(Path.Combine(dir, "TEMPLATE.json"), """
+            {
+              "name": "no_orient",
+              "geometry": {
+                "type": "airfoil",
+                "stlName": "airfoil.stl",
+                "requiredStlFiles": ["airfoil.stl"]
+              },
+              "reference": { "dimension": "chord", "areaFormula": "rectangular" },
+              "rotation": { "enabled": false, "requiresRotorZone": false }
+            }
+            """);
+
+            var metadata = _service.LoadMetadata(dir);
+
+            metadata.Geometry.SurfaceOrient.Should().BeNull();
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Expand TemplateMetadata** to nested schema with geometry, surfaceOrient, reference, rotation, parameters, domain, meshPipeline, solvePipeline, results, and report sections — all driven by TEMPLATE.json
- **Replace hardcoded mesh and solve pipelines** in MeshService and SolverService with generic executors that iterate over `metadata.MeshPipeline` / `metadata.SolvePipeline`, supporting parallelOnly, optional, and parallel step flags
- **Generalize CLI parameters**: velocity/rpm now nullable (no disc-specific defaults), `--template` required, template-driven parameter validation from `metadata.Parameters`
- **Generic results extraction**: `CaseResult.Coefficients` dictionary replaces fixed Cd/Cl/CmPitch properties (backward-compat accessors preserved), CSV export generates dynamic headers
- **Template-driven reports**: each template ships its own `report/report.html` Scriban template, `FindTemplatePath()` searches template-specific directory first, dynamic chart list from Coefficients keys
- **Cleanup**: rename `discStlFile` → `geometryStlFile`, remove hardcoded disc template fallback, update error messages

### Breaking changes
- `--template` flag is now required for `new-study` (no default template)
- `--velocity` and `--rpm` no longer have default values — templates declare which are required
- CSV export no longer includes hardcoded `L_over_D` column (computed columns belong in report templates)

### Stats
- 230 tests passing, 0 failures, 0 warnings
- E2E validated on Linux: airfoil template (new-study → mesh → solve → report)
- 8 commits, touching 20+ files across Models, Services, Handlers, Templates, and Tests

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors (Windows + Linux)
- [x] `dotnet test` — 230 tests passing
- [x] E2E: airfoil template on Linux (new-study → mesh → solve → report all green)
- [ ] E2E: disc template regression on Linux (verify identical results to pre-refactor)
- [ ] E2E: disc AMI transient template smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)