### PR TITLE
fix: update CLI help text for v0.5.0

### DIFF
--- a/Models/NewStudyModel.cs
+++ b/Models/NewStudyModel.cs
@@ -79,10 +79,10 @@ namespace foamscript.Models
 
         // ── Domain geometry parameters ────────────────────────────────────────
 
-        [Option("rotor-radius-scale", Required = false, Default = 1.25, HelpText = "Rotor AMI cylinder radius as a multiple of geometry radius (default: 1.25)")]
+        [Option("rotor-radius-scale", Required = false, Default = 1.25, HelpText = "Rotor cylinder radius as a multiple of reference radius — rotating templates only (default: 1.25)")]
         public double RotorRadiusScale { get; set; } = 1.25;
 
-        [Option("rotor-height-scale", Required = false, Default = 1.5, HelpText = "Rotor AMI cylinder height as a multiple of geometry height (default: 1.5)")]
+        [Option("rotor-height-scale", Required = false, Default = 1.5, HelpText = "Rotor cylinder height as a multiple of geometry height — rotating templates only (default: 1.5)")]
         public double RotorHeightScale { get; set; } = 1.5;
 
         [Option("tunnel-upstream", Required = false, Default = 5.0, HelpText = "Wind tunnel upstream extent in reference lengths (default: 5.0)")]

--- a/Models/ReportModel.cs
+++ b/Models/ReportModel.cs
@@ -2,7 +2,7 @@ using CommandLine;
 
 namespace foamscript.Models
 {
-    [Verb("report", HelpText = "Generate AIAA-quality analysis report (HTML + PDF) with aerodynamic polars, convergence plots, and mesh statistics.")]
+    [Verb("report", HelpText = "Generate AIAA-quality analysis report (HTML + PDF + CSV) with aerodynamic polars, convergence plots, and mesh statistics.")]
     public class ReportModel : VerbModel
     {
         [Option('d', "dir", Required = true, HelpText = "Study or case directory (auto-detects)")]

--- a/Models/ValidateModel.cs
+++ b/Models/ValidateModel.cs
@@ -6,15 +6,11 @@ namespace foamscript.Models
     /// Command verb for validating OpenFOAM environment.
     /// Usage: foamscript validate
     /// </summary>
-    [Verb("validate", HelpText = "Validate OpenFOAM environment and tool availability.")]
+    [Verb("validate", HelpText = "Validate OpenFOAM environment, check all 23 dependencies, and write ~/.foamscript/config.json.")]
     public class ValidateModel : VerbModel
     {
-        [Option('v', "verbose", Required = false, Default = false,
-            HelpText = "Show detailed information about all checks.")]
-        public bool Verbose { get; set; }
-
         [Option('q', "quiet", Required = false, Default = false,
-            HelpText = "Only show errors, suppress success messages.")]
+            HelpText = "Only show failures (exit code only, useful in scripts).")]
         public bool Quiet { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- Remove dead `--verbose` flag from validate command
- Report help text includes CSV
- Rotor options say "rotating templates only" instead of "AMI"

🤖 Generated with [Claude Code](https://claude.com/claude-code)