### PR TITLE
feat: add --version flag and version management (v0.6.0)

### DIFF
--- a/Docs/ExecutiveSummary.md
+++ b/Docs/ExecutiveSummary.md
@@ -1,7 +1,7 @@
 # FoamScript Executive Summary
 
-**Last Updated:** March 17, 2026
-**Version:** 0.5.0 (Template Generalization + Environment Redesign)
+**Last Updated:** March 20, 2026
+**Version:** 0.6.0 (Documentation + Version Management)
 **Repository:** [fusedmfg/foamscript](https://github.com/fusedmfg/foamscript)
 
 *This is a living document revised alongside development. It serves two purposes: (1) document what FoamScript is and how it solves OpenFOAM complexity, and (2) provide an honest narrative on developing this application using a human/AI pair-coding approach.*
@@ -437,9 +437,9 @@ Based on the development history, approximately **70-75% of AI compute was produ
 | Production LOC | 6,880 | Substantial for CLI tool scope |
 | Test LOC | 5,588 | Strong investment |
 | Test/Prod Ratio | 81.2% | Well above industry average (~40-60% typical) |
-| Passing Tests | 241 | Zero failures |
+| Passing Tests | 271 | Zero failures |
 | Template Files | 64 | 3 geometry templates + report templates |
-| GitHub Issues | 39 total (29 closed, 10 open) | Comprehensive tracking |
+| GitHub Issues | 41 total (31 closed, 10 open) | Comprehensive tracking |
 | Build Status | Clean | Zero warnings |
 | Pipeline Validated | Yes | SimFlow match + grid convergence |
 
@@ -602,6 +602,6 @@ The largest cost-optimization opportunity is eliminating rate-limit downtime. Up
 
 ---
 
-*Last updated: March 16, 2026.*
+*Last updated: March 20, 2026.*
 *This is a living document revised alongside development.*
 *AI assistance provided by Anthropic Claude (Sonnet 4.5, Sonnet 4.6, Opus 4.6) via Claude Code.*

--- a/Program.cs
+++ b/Program.cs
@@ -43,9 +43,16 @@ namespace foamscript
                 // Use the documented overload for dynamic type arrays
                 var result = Parser.Default.ParseArguments(args, verbTypes);
 
-                // Check the result of the command-line parsing. If the parsing fails (i.e., if the result is NotParsed), set the exit code to -1 to indicate an error and return immediately, preventing the application from starting with invalid arguments.
+                // Handle parse results: --help and --version are NotParsed but not errors.
                 if (result.Tag == ParserResultType.NotParsed)
                 {
+                    var errors = ((NotParsed<object>)result).Errors;
+                    if (errors.IsHelp() || errors.IsVersion())
+                    {
+                        exitCode = 0;
+                        return;
+                    }
+
                     Log.Fatal("Failed to parse command-line arguments. Exiting application.");
                     exitCode = -1;
                     return;

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Run `foamscript list-templates` to see all available templates with their metada
 
 | Command | Description |
 |---------|-------------|
+| `--version` | Print version and exit |
+| `--help` | Print help and exit |
 | `validate` | Auto-detect OpenFOAM, validate 23 dependencies across 7 groups, write `~/.foamscript/config.json` |
 | `convert` | Convert STEP/IGES → STL in meters (prerequisite for `new-study` when starting from CAD files) |
 | `new-study` | Full pipeline: geometry → domain → templated cases for AoA sweep (`--template` required) |
@@ -110,8 +112,7 @@ foamscript/
 │   ├── CaseService.cs             # Study creation, template context calculation
 │   ├── TemplateMetadataService.cs # TEMPLATE.json loading and validation
 │   ├── StlConversionService.cs    # STEP→STL conversion, validation, scaling
-│   ├── DomainService.cs           # Domain generation (rotor/tunnel STL)
-│   ├── GeometryService.cs         # Facade over StlConversion + Domain services
+│   ├── GeometryService.cs         # Facade over StlConversionService
 │   ├── MeshService.cs             # Template-driven mesh pipeline execution
 │   ├── SolverService.cs           # Template-driven solver execution + log persistence
 │   ├── ResultsService.cs          # Metadata-driven coefficient extraction
@@ -134,7 +135,7 @@ foamscript/
 │       ├── extract_slice.py       # pvpython slice data extraction
 │       └── render_slice.py        # matplotlib contour plot rendering
 ├── Docs/Commands.md     # Full command reference
-├── foamscript.Tests/    # xUnit + Moq + FluentAssertions (241 tests)
+├── foamscript.Tests/    # xUnit + Moq + FluentAssertions (271 tests)
 └── study.example.jsonc  # Example JSON config file
 ```
 

--- a/foamscript.csproj
+++ b/foamscript.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Add `<Version>0.6.0</Version>` to csproj as single source of truth for assembly version
- `foamscript --version` now prints `foamscript 0.6.0+<commit>` (CommandLineParser auto-handles it)
- Fix `--help` and `--version` to exit code 0 instead of -1 (previously treated as parse failures)
- Update README: add --version/--help to commands table, remove deleted DomainService, fix test count (271)
- Update ExecutiveSummary: version 0.6.0, current dates and stats

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 271 passed, 0 failed
- [x] `foamscript --version` — prints `foamscript 0.6.0+<hash>`
- [x] `foamscript --help` — prints help, exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)